### PR TITLE
Move all abstract functionality from QuantumOpticsBase to QuantumInterface

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/breakage.yml
+++ b/.github/workflows/breakage.yml
@@ -17,9 +17,9 @@ jobs:
         pkg: [
           "qojulia/QuantumOpticsBase.jl",
           "qojulia/QuantumOptics.jl",
-          "Krastanov/QSymbolics.jl",
-          "Krastanov/QuantumClifford.jl",
-          "Krastanov/QuantumSavory.jl",
+          "QuantumSavory/QuantumSymbolics.jl",
+          "QuantumSavory/QuantumClifford.jl",
+          "QuantumSavory/QuantumSavory.jl",
         ]
         pkgversion: [latest]
 

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -11,16 +11,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        version:
-          - 'nightly'
-        threads:
-          - 2
-        jet:
-          - 'true'
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            version: nightly
+            threads: 2
+            jet: 'false'
+          - os: ubuntu-latest
+            arch: x64
+            version: '1'
+            threads: 2
+            jet: 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-nightly
 on:
   push:
     branches: [master, main]
@@ -6,27 +6,28 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - t=${{ matrix.threads }} - jet=${{ matrix.jet }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1'
-          - '1.6'
         os:
           - ubuntu-latest
-        threads:
-          - '2'
         arch:
           - x64
+        version:
+          - 'nightly'
+        threads:
+          - 2
+        jet:
+          - 'true'
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:
@@ -40,6 +41,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}
+          JET_TEST: ${{ matrix.jet }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # News
 
+## v0.2.0
+
+- Moving much more of `QuantumOptictsBase` to `QuantumInterface`, avoiding piracy. Now `QuantumInterface` takes care of abstract state/operator types and concrete bases, while `QuantumOpticsBase` has concrete Schroedinger-style implementations of concrete state/operator types. `QuantumClifford` gives tableax-style implementations of concrete state/operator types.
+
 ## v0.1.0
 
-- first release, bringing over interfaces from `QuantumOpticsBase`, `QuantumClifford`, `QuantumSavory`, and `QSymbolics`
+- first release, bringing over interfaces from `QuantumOpticsBase`, `QuantumClifford`, `QuantumSavory`, and `QuantumSymbolics`
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,11 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.1.0"
+version = "0.2.0"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -8,31 +8,25 @@ On the other hand, we do respect semantic versioning, so at worst you would be s
 
 This package contains formal and informal definitions of common interfaces used by:
 
-- [`QuantumOpticsBase.jl`](https://github.com/qojulia/QuantumOpticsBase.jl/)
-- [`QuantumOptics.jl`](https://github.com/qojulia/QuantumOptics.jl/)
-- [`QuantumClifford.jl`](https://github.com/Krastanov/QuantumClifford.jl)
-- [`QSymbolics.jl`](https://github.com/Krastanov/QSymbolics.jl)
-- [`QuantumSavory.jl`](https://github.com/Krastanov/QuantumSavory.jl)
+- [`QuantumOpticsBase.jl`](https://github.com/qojulia/QuantumOpticsBase.jl/) - a library defining data structures for Schroedinger-style quantum simulations (e.g. dense and sparse matrix operators and vector kets)
+- [`QuantumOptics.jl`](https://github.com/qojulia/QuantumOptics.jl/) - provides dynamic equations over types defined in `QuantumOpticsBase`
+- [`QuantumClifford.jl`](https://github.com/Krastanov/QuantumClifford.jl) - implements the typical stabilizer tableaux formalism
+- [`QuantumSymbolics.jl`](https://github.com/Krastanov/QuantumSymbolics.jl) - general purpose symbolic algebra for quantum information science, focusing on automatically transforming symbolic expressions into other formalisms (vectors, tableaux, etc)
+- [`QuantumSavory.jl`](https://github.com/Krastanov/QuantumSavory.jl) - a multi-formalism simulator building up on the other tools
 - [`and others`](https://juliahub.com/ui/Packages/QuantumInterface/a9rji/?page=2)
 
 ```mermaid
 graph TD
     QuantumInterface --> QuantumOpticsBase
     QuantumInterface --> QuantumClifford
-    QuantumInterface --> QSymbolicsBase
-    QSymbolicsBase --> QSymbolicsOptics
+    QuantumInterface --> QuantumSymbolics
     QuantumClifford --> QuantumSavory
-    QuantumClifford --> QSymbolicsClifford
-    QSymbolicsBase --> QSymbolicsClifford
-    QSymbolicsBase --> QSymbolics
-    QSymbolicsClifford --> QSymbolics
-    QSymbolicsOptics --> QSymbolics
+    QuantumClifford --> QSymbolicsExtensions
     subgraph "Symbolics"
-       QSymbolicsBase
-       QSymbolicsOptics
-       QSymbolicsClifford
-       QSymbolics
+       QuantumSymbolics
+       QSymbolicsExtensions[domain specific extensions]
     end
+    QuantumSymbolics --> QSymbolicsExtensions[domain specific extensions]
     subgraph "Clifford circuits"
        QuantumClifford
     end
@@ -42,10 +36,11 @@ graph TD
         QuantumOptics
     end
     QuantumOpticsBase --> QuantumOptics
-    QuantumOpticsBase --> QSymbolicsOptics
+    QuantumOpticsBase --> QSymbolicsExtensions
     subgraph "Multiformalism simulator"
         QuantumSavory
     end
     QuantumOptics --> QuantumSavory
-    QSymbolics --> QuantumSavory
+    QuantumSymbolics --> QuantumSavory
+    QSymbolicsExtensions --> QuantumSavory
 ```

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -75,6 +75,15 @@ function reset_qubits! end
 include("bases.jl")
 include("abstract_types.jl")
 
+include("linalg.jl")
+include("tensor.jl")
+include("embed_permute.jl")
+include("expect_variance.jl")
+include("identityoperator.jl")
+
+include("julia_base.jl")
+include("julia_linalg.jl")
+include("sparse.jl")
 
 include("sortedindices.jl")
 

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -75,4 +75,7 @@ function reset_qubits! end
 include("bases.jl")
 include("abstract_types.jl")
 
+
+include("sortedindices.jl")
+
 end # module

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -66,50 +66,6 @@ function reset_qubits! end
 ##
 
 include("bases.jl")
-
-##
-# States / Operators / SuperOperators
-##
-
-"""
-Abstract base class for `Bra` and `Ket` states.
-
-The state vector class stores the coefficients of an abstract state
-in respect to a certain basis. These coefficients are stored in the
-`data` field and the basis is defined in the `basis`
-field.
-"""
-abstract type StateVector{B,T} end
-abstract type AbstractKet{B,T} <: StateVector{B,T} end
-abstract type AbstractBra{B,T} <: StateVector{B,T} end
-
-"""
-Abstract base class for all operators.
-
-All deriving operator classes have to define the fields
-`basis_l` and `basis_r` defining the left and right side bases.
-
-For fast time evolution also at least the function
-`mul!(result::Ket,op::AbstractOperator,x::Ket,alpha,beta)` should be
-implemented. Many other generic multiplication functions can be defined in
-terms of this function and are provided automatically.
-"""
-abstract type AbstractOperator{BL,BR} end
-
-"""
-Base class for all super operator classes.
-
-Super operators are bijective mappings from operators given in one specific
-basis to operators, possibly given in respect to another, different basis.
-To embed super operators in an algebraic framework they are defined with a
-left hand basis `basis_l` and a right hand basis `basis_r` where each of
-them again consists of a left and right hand basis.
-```math
-A_{bl_1,bl_2} = S_{(bl_1,bl_2) ↔ (br_1,br_2)} B_{br_1,br_2}
-\\\\
-A_{br_1,br_2} = B_{bl_1,bl_2} S_{(bl_1,bl_2) ↔ (br_1,br_2)}
-```
-"""
-abstract type AbstractSuperOperator{B1,B2} end
+include("abstract_types.jl")
 
 end # module

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -1,11 +1,17 @@
 module QuantumInterface
 
+import Base: ==, +, -, *, /, ^, length, one, exp, conj, conj!, transpose, copy
+import LinearAlgebra: tr, ishermitian, norm, normalize, normalize!
+import Base: show, summary
+import SparseArrays: sparse, spzeros, AbstractSparseMatrix # TODO move to an extension
+
 function apply! end
 
 function dagger end
 
 function directsum end
 const ⊕ = directsum
+directsum() = GenericBasis(0)
 
 function dm end
 
@@ -14,6 +20,8 @@ function embed end
 function entanglement_entropy end
 
 function expect end
+
+function identityoperator end
 
 function permutesystems end
 
@@ -41,9 +49,11 @@ function tensor_pow end # TODO should Base.^ be the same as tensor_pow?
 
 function traceout! end
 
+function variance end
+
 ##
 # Qubit specific
-#
+##
 
 function nqubits end
 
@@ -61,9 +71,6 @@ function projectZrand! end
 
 function reset_qubits! end
 
-##
-# Bases
-##
 
 include("bases.jl")
 include("abstract_types.jl")

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -1,0 +1,40 @@
+"""
+Abstract base class for `Bra` and `Ket` states.
+
+The state vector class stores the coefficients of an abstract state
+in respect to a certain basis. These coefficients are stored in the
+`data` field and the basis is defined in the `basis`
+field.
+"""
+abstract type StateVector{B,T} end
+abstract type AbstractKet{B,T} <: StateVector{B,T} end
+abstract type AbstractBra{B,T} <: StateVector{B,T} end
+
+"""
+Abstract base class for all operators.
+
+All deriving operator classes have to define the fields
+`basis_l` and `basis_r` defining the left and right side bases.
+
+For fast time evolution also at least the function
+`mul!(result::Ket,op::AbstractOperator,x::Ket,alpha,beta)` should be
+implemented. Many other generic multiplication functions can be defined in
+terms of this function and are provided automatically.
+"""
+abstract type AbstractOperator{BL,BR} end
+
+"""
+Base class for all super operator classes.
+
+Super operators are bijective mappings from operators given in one specific
+basis to operators, possibly given in respect to another, different basis.
+To embed super operators in an algebraic framework they are defined with a
+left hand basis `basis_l` and a right hand basis `basis_r` where each of
+them again consists of a left and right hand basis.
+```math
+A_{bl_1,bl_2} = S_{(bl_1,bl_2) ↔ (br_1,br_2)} B_{br_1,br_2}
+\\\\
+A_{br_1,br_2} = B_{bl_1,bl_2} S_{(bl_1,bl_2) ↔ (br_1,br_2)}
+```
+"""
+abstract type AbstractSuperOperator{B1,B2} end

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -38,3 +38,18 @@ A_{br_1,br_2} = B_{bl_1,bl_2} S_{(bl_1,bl_2) ↔ (br_1,br_2)}
 ```
 """
 abstract type AbstractSuperOperator{B1,B2} end
+
+function summary(stream::IO, x::AbstractOperator)
+    print(stream, "$(typeof(x).name.name)(dim=$(length(x.basis_l))x$(length(x.basis_r)))\n")
+    if samebases(x)
+        print(stream, "  basis: ")
+        show(stream, basis(x))
+    else
+        print(stream, "  basis left:  ")
+        show(stream, x.basis_l)
+        print(stream, "\n  basis right: ")
+        show(stream, x.basis_r)
+    end
+end
+
+show(stream::IO, x::AbstractOperator) = summary(stream, x)

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -395,3 +395,59 @@ end
 
 embed(b::SumBasis, indices, ops) = embed(b, b, indices, ops)
 
+##
+# show methods
+##
+
+function show(stream::IO, x::GenericBasis)
+    if length(x.shape) == 1
+        write(stream, "Basis(dim=$(x.shape[1]))")
+    else
+        s = replace(string(x.shape), " " => "")
+        write(stream, "Basis(shape=$s)")
+    end
+end
+
+function show(stream::IO, x::CompositeBasis)
+    write(stream, "[")
+    for i in 1:length(x.bases)
+        show(stream, x.bases[i])
+        if i != length(x.bases)
+            write(stream, " ⊗ ")
+        end
+    end
+    write(stream, "]")
+end
+
+function show(stream::IO, x::SpinBasis)
+    d = denominator(x.spinnumber)
+    n = numerator(x.spinnumber)
+    if d == 1
+        write(stream, "Spin($n)")
+    else
+        write(stream, "Spin($n/$d)")
+    end
+end
+
+function show(stream::IO, x::FockBasis)
+    if iszero(x.offset)
+        write(stream, "Fock(cutoff=$(x.N))")
+    else
+        write(stream, "Fock(cutoff=$(x.N), offset=$(x.offset))")
+    end
+end
+
+function show(stream::IO, x::NLevelBasis)
+    write(stream, "NLevel(N=$(x.N))")
+end
+
+function show(stream::IO, x::SumBasis)
+    write(stream, "[")
+    for i in 1:length(x.bases)
+        show(stream, x.bases[i])
+        if i != length(x.bases)
+            write(stream, " ⊕ ")
+        end
+    end
+    write(stream, "]")
+end

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -349,3 +349,49 @@ SpinBasis(spinnumber::Rational) = SpinBasis{spinnumber}(spinnumber)
 SpinBasis(spinnumber) = SpinBasis(convert(Rational{Int}, spinnumber))
 
 Base.:(==)(b1::SpinBasis, b2::SpinBasis) = b1.spinnumber==b2.spinnumber
+
+
+"""
+    SumBasis(b1, b2...)
+
+Similar to [`CompositeBasis`](@ref) but for the [`directsum`](@ref) (⊕)
+"""
+struct SumBasis{S,B} <: Basis
+    shape::S
+    bases::B
+end
+SumBasis(bases) = SumBasis(Int[length(b) for b in bases], bases)
+SumBasis(shape, bases::Vector) = (tmp = (bases...,); SumBasis(shape, tmp))
+SumBasis(bases::Vector) = SumBasis((bases...,))
+SumBasis(bases::Basis...) = SumBasis((bases...,))
+
+==(b1::T, b2::T) where T<:SumBasis = equal_shape(b1.shape, b2.shape)
+==(b1::SumBasis, b2::SumBasis) = false
+length(b::SumBasis) = sum(b.shape)
+
+"""
+    directsum(b1::Basis, b2::Basis)
+
+Construct the [`SumBasis`](@ref) out of two sub-bases.
+"""
+directsum(b1::Basis, b2::Basis) = SumBasis(Int[length(b1); length(b2)], Basis[b1, b2])
+directsum(b::Basis) = b
+directsum(b::Basis...) = reduce(directsum, b)
+function directsum(b1::SumBasis, b2::Basis)
+    shape = [b1.shape;length(b2)]
+    bases = [b1.bases...;b2]
+    return SumBasis(shape, (bases...,))
+end
+function directsum(b1::Basis, b2::SumBasis)
+    shape = [length(b1);b2.shape]
+    bases = [b1;b2.bases...]
+    return SumBasis(shape, (bases...,))
+end
+function directsum(b1::SumBasis, b2::SumBasis)
+    shape = [b1.shape;b2.shape]
+    bases = [b1.bases...;b2.bases...]
+    return SumBasis(shape, (bases...,))
+end
+
+embed(b::SumBasis, indices, ops) = embed(b, b, indices, ops)
+

--- a/src/embed_permute.jl
+++ b/src/embed_permute.jl
@@ -19,7 +19,7 @@ function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
     start_indices_flat = [i[1] for i in indices]
     complement_indices_flat = Int[i for i=1:N if i ∉ indices_flat]
     operators_flat = AbstractOperator[]
-    if all([minimum(I):maximum(I);]==I for I in indices)
+    if all(([minimum(I):maximum(I);]==I)::Bool for I in indices) # type assertion to help type inference
         for i in 1:N
             if i in complement_indices_flat
                 push!(operators_flat, identityoperator(T, S, basis_l.bases[i], basis_r.bases[i]))

--- a/src/embed_permute.jl
+++ b/src/embed_permute.jl
@@ -1,0 +1,86 @@
+
+"""
+    embed(basis1[, basis2], operators::Dict)
+
+`operators` is a dictionary `Dict{Vector{Int}, AbstractOperator}`. The integer vector
+specifies in which subsystems the corresponding operator is defined.
+"""
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
+               operators::Dict{<:Vector{<:Integer}, T}) where T<:AbstractOperator
+    @assert length(basis_l.bases) == length(basis_r.bases)
+    N = length(basis_l.bases)::Int # type assertion to help type inference
+    if length(operators) == 0
+        return identityoperator(T, basis_l, basis_r)
+    end
+    indices, operator_list = zip(operators...)
+    operator_list = [operator_list...;]
+    S = mapreduce(eltype, promote_type, operator_list)
+    indices_flat = [indices...;]::Vector{Int} # type assertion to help type inference
+    start_indices_flat = [i[1] for i in indices]
+    complement_indices_flat = Int[i for i=1:N if i ∉ indices_flat]
+    operators_flat = AbstractOperator[]
+    if all([minimum(I):maximum(I);]==I for I in indices)
+        for i in 1:N
+            if i in complement_indices_flat
+                push!(operators_flat, identityoperator(T, S, basis_l.bases[i], basis_r.bases[i]))
+            elseif i in start_indices_flat
+                push!(operators_flat, operator_list[indexin(i, start_indices_flat)[1]])
+            end
+        end
+        return tensor(operators_flat...)
+    else
+        complement_operators = [identityoperator(T, S, basis_l.bases[i], basis_r.bases[i]) for i in complement_indices_flat]
+        op = tensor([operator_list; complement_operators]...)
+        perm = sortperm([indices_flat; complement_indices_flat])
+        return permutesystems(op, perm)
+    end
+end
+embed(basis_l::CompositeBasis, basis_r::CompositeBasis, operators::Dict{<:Integer, T}; kwargs...) where {T<:AbstractOperator} = embed(basis_l, basis_r, Dict([i]=>op_i for (i, op_i) in operators); kwargs...)
+embed(basis::CompositeBasis, operators::Dict{<:Integer, T}; kwargs...) where {T<:AbstractOperator} = embed(basis, basis, operators; kwargs...)
+embed(basis::CompositeBasis, operators::Dict{<:Vector{<:Integer}, T}; kwargs...) where {T<:AbstractOperator} = embed(basis, basis, operators; kwargs...)
+
+# The dictionary implementation works for non-DataOperators
+embed(basis_l::CompositeBasis, basis_r::CompositeBasis, indices, op::T) where T<:AbstractOperator = embed(basis_l, basis_r, Dict(indices=>op))
+
+embed(basis_l::CompositeBasis, basis_r::CompositeBasis, index::Integer, op::AbstractOperator) = embed(basis_l, basis_r, index, [op])
+embed(basis::CompositeBasis, indices, operators::Vector{T}) where {T<:AbstractOperator} = embed(basis, basis, indices, operators)
+embed(basis::CompositeBasis, indices, op::AbstractOperator) = embed(basis, basis, indices, op)
+
+
+"""
+    embed(basis1[, basis2], indices::Vector, operators::Vector)
+
+Tensor product of operators where missing indices are filled up with identity operators.
+"""
+function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
+               indices, operators::Vector{T}) where T<:AbstractOperator
+
+    @assert check_embed_indices(indices)
+
+    N = length(basis_l.bases)
+    @assert length(basis_r.bases) == N
+    @assert length(indices) == length(operators)
+
+    # Embed all single-subspace operators.
+    idxop_sb = [x for x in zip(indices, operators) if x[1] isa Integer]
+    indices_sb = [x[1] for x in idxop_sb]
+    ops_sb = [x[2] for x in idxop_sb]
+
+    for (idxsb, opsb) in zip(indices_sb, ops_sb)
+        (opsb.basis_l == basis_l.bases[idxsb]) || throw(IncompatibleBases())
+        (opsb.basis_r == basis_r.bases[idxsb]) || throw(IncompatibleBases())
+    end
+
+    S = length(operators) > 0 ? mapreduce(eltype, promote_type, operators) : Any
+    embed_op = tensor([i ∈ indices_sb ? ops_sb[indexin(i, indices_sb)[1]] : identityoperator(T, S, basis_l.bases[i], basis_r.bases[i]) for i=1:N]...)
+
+    # Embed all joint-subspace operators.
+    idxop_comp = [x for x in zip(indices, operators) if x[1] isa Array]
+    for (idxs, op) in idxop_comp
+        embed_op *= embed(basis_l, basis_r, idxs, op)
+    end
+
+    return embed_op
+end
+
+permutesystems(a::AbstractOperator, perm) = arithmetic_unary_error("Permutations of subsystems", a)

--- a/src/expect_variance.jl
+++ b/src/expect_variance.jl
@@ -1,0 +1,35 @@
+"""
+    expect(index, op, state)
+
+If an `index` is given, it assumes that `op` is defined in the subsystem specified by this number.
+"""
+function expect(indices, op::AbstractOperator{B1,B2}, state::AbstractOperator{B3,B3}) where {B1,B2,B3<:CompositeBasis}
+    N = length(state.basis_l.shape)
+    indices_ = complement(N, indices)
+    expect(op, ptrace(state, indices_))
+end
+
+expect(index::Integer, op::AbstractOperator{B1,B2}, state::AbstractOperator{B3,B3}) where {B1,B2,B3<:CompositeBasis} = expect([index], op, state)
+expect(op::AbstractOperator, states::Vector) = [expect(op, state) for state=states]
+expect(indices, op::AbstractOperator, states::Vector) = [expect(indices, op, state) for state=states]
+
+expect(op::AbstractOperator{B1,B2}, state::AbstractOperator{B2,B2}) where {B1,B2} = tr(op*state)
+
+"""
+    variance(index, op, state)
+
+If an `index` is given, it assumes that `op` is defined in the subsystem specified by this number
+"""
+function variance(indices, op::AbstractOperator{B,B}, state::AbstractOperator{BC,BC}) where {B,BC<:CompositeBasis}
+    N = length(state.basis_l.shape)
+    indices_ = complement(N, indices)
+    variance(op, ptrace(state, indices_))
+end
+
+variance(index::Integer, op::AbstractOperator{B,B}, state::AbstractOperator{BC,BC}) where {B,BC<:CompositeBasis} = variance([index], op, state)
+variance(op::AbstractOperator, states::Vector) = [variance(op, state) for state=states]
+variance(indices, op::AbstractOperator, states::Vector) = [variance(indices, op, state) for state=states]
+
+function variance(op::AbstractOperator{B,B}, state::AbstractOperator{B,B}) where B
+    expect(op*op, state) - expect(op, state)^2
+end

--- a/src/identityoperator.jl
+++ b/src/identityoperator.jl
@@ -1,0 +1,23 @@
+one(x::Union{<:Basis,<:AbstractOperator}) = identityoperator(x)
+
+"""
+    identityoperator(a::Basis[, b::Basis])
+    identityoperator(::Type{<:AbstractOperator}, a::Basis[, b::Basis])
+    identityoperator(::Type{<:Number}, a::Basis[, b::Basis])
+    identityoperator(::Type{<:AbstractOperator}, ::Type{<:Number}, a::Basis[, b::Basis])
+
+Return an identityoperator in the given bases. One can optionally specify the container
+type which has to a subtype of [`AbstractOperator`](@ref) as well as the number type
+to be used in the identity matrix.
+"""
+identityoperator(::Type{T}, ::Type{S}, b1::Basis, b2::Basis) where {T<:AbstractOperator,S} = throw(ArgumentError("Identity operator not defined for operator type $T."))
+identityoperator(::Type{T}, ::Type{S}, b::Basis) where {T<:AbstractOperator,S} = identityoperator(T,S,b,b)
+identityoperator(::Type{T}, bases::Basis...) where T<:AbstractOperator = identityoperator(T,eltype(T),bases...)
+identityoperator(b::Basis) = identityoperator(b,b)
+identityoperator(op::T) where {T<:AbstractOperator} = identityoperator(T, op.basis_l, op.basis_r)
+
+# Catch case where eltype cannot be inferred from type; this is a bit hacky
+identityoperator(::Type{T}, ::Type{Any}, b1::Basis, b2::Basis) where T<:AbstractOperator = identityoperator(T, ComplexF64, b1, b2)
+
+identityoperator(::Type{T}, b::Basis) where T<:Number = identityoperator(T, b, b)
+identityoperator(b1::Basis, b2::Basis) = identityoperator(ComplexF64, b1, b2)

--- a/src/julia_base.jl
+++ b/src/julia_base.jl
@@ -59,7 +59,7 @@ exp(op::AbstractOperator) = throw(ArgumentError("exp() is not defined for this t
 
 Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
 function Base.size(op::AbstractOperator, i::Int)
-    i < 1 && throw(ErrorException(lazy"dimension out of range, should be strictly positive, got $i"))
+    i < 1 && throw(ErrorException("dimension index is < 1"))
     i > 2 && return 1
     i==1 ? length(op.basis_l) : length(op.basis_r)
 end

--- a/src/julia_base.jl
+++ b/src/julia_base.jl
@@ -1,0 +1,70 @@
+# Common error messages
+arithmetic_unary_error(funcname, x::AbstractOperator) = throw(ArgumentError("$funcname is not defined for this type of operator: $(typeof(x)).\nTry to convert to another operator type first with e.g. dense() or sparse()."))
+arithmetic_binary_error(funcname, a::AbstractOperator, b::AbstractOperator) = throw(ArgumentError("$funcname is not defined for this combination of types of operators: $(typeof(a)), $(typeof(b)).\nTry to convert to a common operator type first with e.g. dense() or sparse()."))
+addnumbererror() = throw(ArgumentError("Can't add or subtract a number and an operator. You probably want 'op + identityoperator(op)*x'."))
+
+
+##
+# States
+##
+
+-(a::T) where {T<:StateVector} = T(a.basis, -a.data)
+*(a::StateVector, b::Number) = b*a
+copy(a::T) where {T<:StateVector} = T(a.basis, copy(a.data))
+length(a::StateVector) = length(a.basis)::Int
+basis(a::StateVector) = a.basis
+directsum(x::StateVector...) = reduce(directsum, x)
+
+# Array-like functions
+Base.size(x::StateVector) = size(x.data)
+@inline Base.axes(x::StateVector) = axes(x.data)
+Base.ndims(x::StateVector) = 1
+Base.ndims(::Type{<:StateVector}) = 1
+Base.eltype(x::StateVector) = eltype(x.data)
+
+# Broadcasting
+Base.broadcastable(x::StateVector) = x
+
+
+##
+# Operators
+##
+
+length(a::AbstractOperator) = length(a.basis_l)::Int*length(a.basis_r)::Int
+basis(a::AbstractOperator) = (check_samebases(a); a.basis_l)
+
+# Ensure scalar broadcasting
+Base.broadcastable(x::AbstractOperator) = Ref(x)
+
+# Arithmetic operations
++(a::AbstractOperator, b::AbstractOperator) = arithmetic_binary_error("Addition", a, b)
++(a::Number, b::AbstractOperator) = addnumbererror()
++(a::AbstractOperator, b::Number) = addnumbererror()
++(a::AbstractOperator) = a
+
+-(a::AbstractOperator) = arithmetic_unary_error("Negation", a)
+-(a::AbstractOperator, b::AbstractOperator) = arithmetic_binary_error("Subtraction", a, b)
+-(a::Number, b::AbstractOperator) = addnumbererror()
+-(a::AbstractOperator, b::Number) = addnumbererror()
+
+*(a::AbstractOperator, b::AbstractOperator) = arithmetic_binary_error("Multiplication", a, b)
+^(a::AbstractOperator, b::Integer) = Base.power_by_squaring(a, b)
+
+"""
+    exp(op::AbstractOperator)
+
+Operator exponential.
+"""
+exp(op::AbstractOperator) = throw(ArgumentError("exp() is not defined for this type of operator: $(typeof(op)).\nTry to convert to dense operator first with dense()."))
+
+Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
+function Base.size(op::AbstractOperator, i::Int)
+    i < 1 && throw(ErrorException(lazy"dimension out of range, should be strictly positive, got $i"))
+    i > 2 && return 1
+    i==1 ? length(op.basis_l) : length(op.basis_r)
+end
+
+Base.adjoint(a::AbstractOperator) = dagger(a)
+
+conj(a::AbstractOperator) = arithmetic_unary_error("Complex conjugate", a)
+conj!(a::AbstractOperator) = conj(a::AbstractOperator)

--- a/src/julia_linalg.jl
+++ b/src/julia_linalg.jl
@@ -1,0 +1,48 @@
+"""
+    ishermitian(op::AbstractOperator)
+
+Check if an operator is Hermitian.
+"""
+ishermitian(op::AbstractOperator) = arithmetic_unary_error(ishermitian, op)
+
+"""
+    tr(x::AbstractOperator)
+
+Trace of the given operator.
+"""
+tr(x::AbstractOperator) = arithmetic_unary_error("Trace", x)
+
+"""
+    norm(x::StateVector)
+
+Norm of the given bra or ket state.
+"""
+norm(x::StateVector) = norm(x.data)
+
+"""
+    normalize(x::StateVector)
+
+Return the normalized state so that `norm(x)` is one.
+"""
+normalize(x::StateVector) = x/norm(x)
+
+"""
+    normalize!(x::StateVector)
+
+In-place normalization of the given bra or ket so that `norm(x)` is one.
+"""
+normalize!(x::StateVector) = (normalize!(x.data); x)
+
+"""
+    normalize(op)
+
+Return the normalized operator so that its `tr(op)` is one.
+"""
+normalize(op::AbstractOperator) = op/tr(op)
+
+"""
+    normalize!(op)
+
+In-place normalization of the given operator so that its `tr(x)` is one.
+"""
+normalize!(op::AbstractOperator) = throw(ArgumentError("normalize! is not defined for this type of operator: $(typeof(op)).\n You may have to fall back to the non-inplace version 'normalize()'."))

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,0 +1,10 @@
+samebases(a::AbstractOperator) = samebases(a.basis_l, a.basis_r)::Bool
+samebases(a::AbstractOperator, b::AbstractOperator) = samebases(a.basis_l, b.basis_l)::Bool && samebases(a.basis_r, b.basis_r)::Bool
+check_samebases(a::AbstractOperator) = check_samebases(a.basis_l, a.basis_r)
+multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_r, b.basis_l)
+dagger(a::AbstractOperator) = arithmetic_unary_error("Hermitian conjugate", a)
+transpose(a::AbstractOperator) = arithmetic_unary_error("Transpose", a)
+directsum(a::AbstractOperator...) = reduce(directsum, a)
+ptrace(a::AbstractOperator, index) = arithmetic_unary_error("Partial trace", a)
+_index_complement(b::CompositeBasis, indices) = complement(length(b.bases), indices)
+reduced(a, indices) = ptrace(a, _index_complement(basis(a), indices))

--- a/src/sortedindices.jl
+++ b/src/sortedindices.jl
@@ -1,0 +1,117 @@
+"""
+6, [1, 4] => [2, 3, 5, 6]
+"""
+function complement(N, indices)
+    L = length(indices)
+    x = Vector{Int}(undef, N - L)
+    i_ = 1 # Position in the x vector
+    j = 1 # Position in indices vector
+    for i=1:N
+        if j > L || indices[j]!=i
+            x[i_] = i
+            i_ += 1
+        else
+            j += 1
+        end
+    end
+    x
+end
+
+
+"""
+[1, 4, 5], [2, 4, 7] => [1, 5]
+"""
+function remove(ind1, ind2)
+    x = Int[]
+    for i in ind1
+        if i ∉ ind2
+            push!(x, i)
+        end
+    end
+    x
+end
+
+"""
+[1, 4, 5], [2, 4, 7] => [1, 3]
+"""
+function shiftremove(ind1, ind2)
+    x = Int[]
+    for i in ind1
+        if i ∉ ind2
+            counter = 0
+            for i2 in ind2
+                if i2 < i
+                    counter += 1
+                else
+                    break
+                end
+            end
+            push!(x, i-counter)
+        end
+    end
+    x
+end
+
+function reducedindices(I_, I)
+    N = length(I_)
+    x = Vector{Int}(undef, N)
+    for n in 1:N
+        x[n] = findfirst(isequal(I_[n]), I)
+    end
+    x
+end
+
+function reducedindices!(I_, I)
+    for n in 1:length(I_)
+        I_[n] = findfirst(isequal(I_[n]), I)
+    end
+end
+
+"""
+Check if all indices are unique and smaller than or equal to imax.
+"""
+function check_indices(imax, indices)
+    N = length(indices)
+    for n=1:N
+        i = indices[n]
+        @assert 0 < i <= imax
+        for m in n+1:N
+            @assert i != indices[m]
+        end
+    end
+end
+
+"""
+Check if the indices are sorted, unique and smaller than or equal to imax.
+"""
+function check_sortedindices(imax, indices)
+    N = length(indices)
+    if N == 0
+        return nothing
+    end
+    i_ = indices[1]
+    @assert 0 < i_ <= imax
+    for i in indices[2:end]
+        @assert 0 < i <= imax
+        @assert i > i_
+    end
+end
+
+"""
+    check_embed_indices(indices::Array)
+
+Determine whether a collection of indices, written as a list of (integers or lists of integers) is unique.
+This assures that the embedded operators are in non-overlapping subspaces.
+"""
+function check_embed_indices(indices)
+    # short circuit return when `indices` is empty.
+    length(indices) == 0 && return true
+
+    err_str = "Variable `indices` comes in an unexpected form. Expecting `Array{Union{Int, Array{Int, 1}}, 1}`"
+    @assert all(x isa Array || x isa Int for x in indices) err_str
+
+    # flatten the indices and check for uniqueness
+    # use a custom flatten because it's ≈ 4x  faster than Base.Iterators.flatten
+    flatten(arr) = mapreduce(x -> x isa Vector ? flatten(x) : x, append!, arr, init=[])
+    allunique(flatten(indices))
+end

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -1,0 +1,34 @@
+# TODO make an extension?
+
+# dense(a::AbstractOperator) = arithmetic_unary_error("Conversion to dense", a)
+
+"""
+    sparse(op::AbstractOperator)
+
+Convert an arbitrary operator into a [`SparseOperator`](@ref).
+"""
+sparse(a::AbstractOperator) = throw(ArgumentError("Direct conversion from $(typeof(a)) not implemented. Use sparse(full(op)) from QuantumOptics instead."))
+
+function ptrace(x::AbstractSparseMatrix, shape_nd, indices)
+    shape_nd = (shape_nd...,)
+    N = div(length(shape_nd), 2)
+    shape_2d = (x.m, x.n)
+    shape_nd_after = ([i ∈ indices || i-N ∈ indices ? 1 : shape_nd[i] for i=1:2*N]...,)
+    shape_2d_after = (prod(shape_nd_after[1:N]), prod(shape_nd_after[N+1:end]))
+    I_nd_after_max = CartesianIndex(shape_nd_after...)
+    y = spzeros(eltype(x), shape_2d_after...)
+    for I in eachindex(x)
+        I_nd = sub2sub(shape_2d, shape_nd, I)
+        if I_nd.I[indices] != I_nd.I[indices .+ N]
+            continue
+        end
+        I_after = sub2sub(shape_nd_after, shape_2d_after, min(I_nd, I_nd_after_max))
+        y[I_after] += x[I]
+    end
+    y
+end
+
+function sub2sub(shape1, shape2, I)
+    linearindex = LinearIndices(shape1)[I.I...]
+    CartesianIndices(shape2)[linearindex]
+end

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -1,0 +1,10 @@
+"""
+    tensor(x::AbstractOperator, y::AbstractOperator, z::AbstractOperator...)
+
+Tensor product ``\\hat{x}⊗\\hat{y}⊗\\hat{z}⊗…`` of the given operators.
+"""
+tensor(a::AbstractOperator, b::AbstractOperator) = arithmetic_binary_error("Tensor product", a, b)
+tensor(op::AbstractOperator) = op
+tensor(operators::AbstractOperator...) = reduce(tensor, operators)
+tensor(state::StateVector) = state
+tensor(states::Vector{T}) where T<:StateVector = reduce(tensor, states)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,31 @@
+using SafeTestsets
 using QuantumInterface
-using Test
 
-@testset "QuantumInterface.jl" begin
-    # Write your tests here.
+function doset(descr)
+    if length(ARGS) == 0
+        return true
+    end
+    for a in ARGS
+        if occursin(lowercase(a), lowercase(descr))
+            return true
+        end
+    end
+    return false
 end
+
+macro doset(descr)
+    quote
+        if doset($descr)
+            @safetestset $descr begin
+                include("test_"*$descr*".jl")
+            end
+        end
+    end
+end
+
+println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
+
+@doset "sortedindices"
+#VERSION >= v"1.9" && @doset "doctests"
+get(ENV,"JET_TEST","")=="true" && @doset "jet"
+VERSION >= v"1.9" && @doset "aqua"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,3 @@
+using Aqua
+using QuantumInterface
+Aqua.test_all(QuantumInterface)

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -1,0 +1,29 @@
+using QuantumInterface
+using JET
+
+using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport
+
+# Custom report pass that ignores `UncaughtExceptionReport`
+# Too coarse currently, but it serves to ignore the various
+# "may throw" messages for runtime errors we raise on purpose
+# (mostly on malformed user input)
+struct MayThrowIsOk <: ReportPass end
+
+# ignores `UncaughtExceptionReport` analyzed by `JETAnalyzer`
+(::MayThrowIsOk)(::Type{UncaughtExceptionReport}, @nospecialize(_...)) = return
+
+# forward to `BasicPass` for everything else
+function (::MayThrowIsOk)(report_type::Type{<:InferenceErrorReport}, @nospecialize(args...))
+    BasicPass()(report_type, args...)
+end
+
+@testset "JET checks" begin
+    rep = report_package("QuantumInterface";
+        report_pass=MayThrowIsOk(),
+        ignored_modules=(
+            #AnyFrameModule(...),
+        )
+    )
+    @show rep
+    @test length(JET.get_reports(rep)) == 0
+end

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -1,13 +1,18 @@
 using QuantumInterface
 using JET
 
-using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport
+using JET: ReportPass, BasicPass, InferenceErrorReport, UncaughtExceptionReport, MethodErrorReport
 
 # Custom report pass that ignores `UncaughtExceptionReport`
 # Too coarse currently, but it serves to ignore the various
 # "may throw" messages for runtime errors we raise on purpose
 # (mostly on malformed user input)
 struct MayThrowIsOk <: ReportPass end
+
+# We define abstract methods, so it is unsurprising that there are no matching methods unless
+# we import other libraries.
+# TODO find a more fine-grained way to check these.
+struct NoMatchingMethodIsOK <: ReportPass end
 
 # ignores `UncaughtExceptionReport` analyzed by `JETAnalyzer`
 (::MayThrowIsOk)(::Type{UncaughtExceptionReport}, @nospecialize(_...)) = return
@@ -17,9 +22,26 @@ function (::MayThrowIsOk)(report_type::Type{<:InferenceErrorReport}, @nospeciali
     BasicPass()(report_type, args...)
 end
 
+# ignores `UncaughtExceptionReport` and `MethodErrorReport` analyzed by `JETAnalyzer`
+(::NoMatchingMethodIsOK)(::Type{MethodErrorReport}, @nospecialize(_...)) = return
+
+# forward to `MayThrowIsOk` for everything else
+function (::NoMatchingMethodIsOK)(report_type::Type{<:InferenceErrorReport}, @nospecialize(args...))
+    MayThrowIsOk()(report_type, args...)
+end
+
 @testset "JET checks" begin
     rep = report_package("QuantumInterface";
         report_pass=MayThrowIsOk(),
+        ignored_modules=(
+            #AnyFrameModule(...),
+        )
+    )
+    @show rep
+    @test length(JET.get_reports(rep)) <= 4
+
+    rep = report_package("QuantumInterface";
+        report_pass=NoMatchingMethodIsOK(),
         ignored_modules=(
             #AnyFrameModule(...),
         )

--- a/test/test_sortedindices.jl
+++ b/test/test_sortedindices.jl
@@ -1,0 +1,37 @@
+using Test
+using QuantumInterface
+
+s = QuantumInterface
+
+@test s.complement(6, [1, 4]) == [2, 3, 5, 6]
+
+@test s.remove([1, 4, 5], [2, 4, 7]) == [1, 5]
+@test s.remove([1, 4, 5, 7], [2, 4, 7]) == [1, 5]
+@test s.remove([1, 4, 5, 8], [2, 4, 7]) == [1, 5, 8]
+
+@test s.shiftremove([1, 4, 5], [2, 4, 7]) == [1, 3]
+@test s.shiftremove([1, 4, 5, 7], [2, 4, 7]) == [1, 3]
+@test s.shiftremove([1, 4, 5, 8], [2, 4, 7]) == [1, 3, 5]
+
+@test s.reducedindices([3, 5], [2, 3, 5, 6]) == [2, 3]
+x = [3, 5]
+s.reducedindices!(x, [2, 3, 5, 6])
+@test x == [2, 3]
+
+@test_throws AssertionError s.check_indices(5, [1, 6])
+@test_throws AssertionError s.check_indices(5, [0, 2])
+@test s.check_indices(5, Int[]) == nothing
+@test s.check_indices(5, [1, 3]) == nothing
+@test s.check_indices(5, [3, 1]) == nothing
+
+@test_throws AssertionError s.check_sortedindices(5, [1, 6])
+@test_throws AssertionError s.check_sortedindices(5, [3, 1])
+@test_throws AssertionError s.check_sortedindices(5, [0, 2])
+@test s.check_sortedindices(5, Int[]) == nothing
+@test s.check_sortedindices(5, [1, 3]) == nothing
+
+@test s.check_embed_indices([1,[3,5],10,2,[70,11]]) == true
+@test s.check_embed_indices([1,3,1]) == false
+@test s.check_embed_indices([1,[10,11],7,[3,1]]) == false
+@test s.check_embed_indices([[10,3],5,6,[3,7]]) == false
+@test s.check_embed_indices([]) == true


### PR DESCRIPTION
- fixes piracy issues
- makes the distinctions between QuantumOpticsBase and QuantumInterface clearer
  - QuantumInterface is for abstract types and concrete bases (so it can be used by QuantumSymbolics, QuantumClifford, and QuantumSavory)
  - QuantumOpticsBase is for concrete datastructures for Schroedinger-style simulations
  - QuantumOptics is for dynamics over types defined in QuantumOpticsBase

Surprisingly, this was very easy. There is only one difficult piracy issue to be fixed, a testament of how well abstracted the two layers of QuantumOpticsBase have been from before the split into QuantumInterface.

No new functionality is added. No functionality is removed. Almost all piracy issues are fixed. Significant new tests are added.

This is a breaking version -- 0.2.0. It will not be used by any other library until their compat field is updated.

I will wait a weak or so for review, but as there are no functionality changes, only moving code around, I will not block the merge waiting on review. Let me know if you prefer I take it slower. We can have slower more thorough merge window on the QuantumOpticsBase side of things.

fixes https://github.com/qojulia/QuantumInterface.jl/issues/4