### PR TITLE
extend `basis()` to support SuperOperator

### DIFF
--- a/src/bases.jl
+++ b/src/bases.jl
@@ -165,6 +165,7 @@ end
 Test if two objects have the same bases.
 """
 samebases(b1::Basis, b2::Basis) = b1==b2
+samebases(b1::Tuple{Basis, Basis}, b2::Tuple{Basis, Basis}) = b1==b2 # for checking superoperators
 
 """
     check_samebases(a, b)

--- a/src/julia_base.jl
+++ b/src/julia_base.jl
@@ -32,6 +32,7 @@ Base.broadcastable(x::StateVector) = x
 
 length(a::AbstractOperator) = length(a.basis_l)::Int*length(a.basis_r)::Int
 basis(a::AbstractOperator) = (check_samebases(a); a.basis_l)
+basis(a::AbstractSuperOperator) = (check_samebases(a); a.basis_l)
 
 # Ensure scalar broadcasting
 Base.broadcastable(x::AbstractOperator) = Ref(x)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,6 +1,6 @@
 samebases(a::AbstractOperator) = samebases(a.basis_l, a.basis_r)::Bool
 samebases(a::AbstractOperator, b::AbstractOperator) = samebases(a.basis_l, b.basis_l)::Bool && samebases(a.basis_r, b.basis_r)::Bool
-check_samebases(a::AbstractOperator) = check_samebases(a.basis_l, a.basis_r)
+check_samebases(a::Union{AbstractOperator, AbstractSuperOperator}) = check_samebases(a.basis_l, a.basis_r)
 multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_r, b.basis_l)
 dagger(a::AbstractOperator) = arithmetic_unary_error("Hermitian conjugate", a)
 transpose(a::AbstractOperator) = arithmetic_unary_error("Transpose", a)


### PR DESCRIPTION
Needed for qojulia/QuantumOpticsBase.jl/pull/103