### PR TITLE
Add adjoint for StateVector

### DIFF
--- a/src/julia_base.jl
+++ b/src/julia_base.jl
@@ -25,6 +25,8 @@ Base.eltype(x::StateVector) = eltype(x.data)
 # Broadcasting
 Base.broadcastable(x::StateVector) = x
 
+Base.adjoint(a::StateVector) = dagger(a)
+
 
 ##
 # Operators


### PR DESCRIPTION
This is still defined in QuantumOpticsBase, so should be removed from there after this is in.