### PR TITLE
bumb to 0.2.2 and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.2.2
+
+- Move `Base.adjoint` from `QuantumOpticsBase` to `QuantumInterface`.
+
 ## v0.2.1
 
 - Implement `basis` method for superoperators.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/test_jet.jl
+++ b/test/test_jet.jl
@@ -38,7 +38,7 @@ end
         )
     )
     @show rep
-    @test length(JET.get_reports(rep)) <= 6
+    @test length(JET.get_reports(rep)) <= 7
 
     rep = report_package("QuantumInterface";
         report_pass=NoMatchingMethodIsOK(),


### PR DESCRIPTION
Following up on the move of `Base.adjoint` -- we can merge this just before the QuantumOpticsBase deletion of that method. I am marking it as non-breaking because at worst it would just show some warnings about redefined methods.