### PR TITLE
Fix cross-reference to SparseOperator which only exists in QOBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -5,7 +5,9 @@
 """
     sparse(op::AbstractOperator)
 
-Convert an arbitrary operator into a [`SparseOperator`](@ref).
+Convert an arbitrary operator into a sparse one.
+
+See also: QuantumOpticsBase.SparseOperator
 """
 sparse(a::AbstractOperator) = throw(ArgumentError("Direct conversion from $(typeof(a)) not implemented. Use sparse(full(op)) from QuantumOptics instead."))
 


### PR DESCRIPTION
This currently causes documentation builds to fail.