### PR TITLE
Move several functions from QOBase

### DIFF
--- a/.github/workflows/changelog-enforcer.yml
+++ b/.github/workflows/changelog-enforcer.yml
@@ -1,0 +1,15 @@
+name: "Changelog Enforcer"
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # News
 
+## v0.3.6 - 2024-09-08
+
+- Add `coherentstate`, `thermalstate`, `displace`, `squeeze`, `wigner`, previously from QuantumOptics.
+
+## v0.3.5
+
+- Fix piracies and ambiguities in `nsubsystems` accumulated downstream in QuantumSavory.
+
+## v0.3.4
+
+- Documentation build fix.
+
 ## v0.3.3
 
 - Add `nsubsystems` for computing the number of subsystems in a state.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -71,6 +71,19 @@ function projectZrand! end
 
 function reset_qubits! end
 
+##
+# Quantum optics specific
+
+function coherentstate end
+
+function thermalstate end
+
+function displace end
+
+function squeeze end
+
+function wigner end
+
 
 include("bases.jl")
 include("abstract_types.jl")

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -73,6 +73,7 @@ function reset_qubits! end
 
 ##
 # Quantum optics specific
+##
 
 function coherentstate end
 


### PR DESCRIPTION
In preparation for a Gaussian quantum optics package, I am moving the following function definitions to this  interface:
`coherentstate`, `thermalstate`, `displace`, `squeeze`, `wigner`.