### PR TITLE
Define apply function that does not modify arguments

### DIFF
--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -5,6 +5,8 @@ import LinearAlgebra: tr, ishermitian, norm, normalize, normalize!
 import Base: show, summary
 import SparseArrays: sparse, spzeros, AbstractSparseMatrix # TODO move to an extension
 
+function apply end
+
 function apply! end
 
 function dagger end


### PR DESCRIPTION
In preparation for the Gaussian quantum information package. `apply` would be useful to define here, as other packages in QuantumSavory use `apply!`.