### PR TITLE
Add test_bases from QuantumOpticsBase and reorganize a bit

### DIFF
--- a/src/embed_permute.jl
+++ b/src/embed_permute.jl
@@ -67,8 +67,8 @@ function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
     ops_sb = [x[2] for x in idxop_sb]
 
     for (idxsb, opsb) in zip(indices_sb, ops_sb)
-        (opsb.basis_l == basis_l.bases[idxsb]) || throw(IncompatibleBases())
-        (opsb.basis_r == basis_r.bases[idxsb]) || throw(IncompatibleBases())
+        (opsb.basis_l == basis_l.bases[idxsb]) || throw(IncompatibleBases()) # FIXME issue #12
+        (opsb.basis_r == basis_r.bases[idxsb]) || throw(IncompatibleBases()) # FIXME issue #12
     end
 
     S = length(operators) > 0 ? mapreduce(eltype, promote_type, operators) : Any

--- a/src/julia_base.jl
+++ b/src/julia_base.jl
@@ -8,19 +8,19 @@ addnumbererror() = throw(ArgumentError("Can't add or subtract a number and an op
 # States
 ##
 
--(a::T) where {T<:StateVector} = T(a.basis, -a.data)
+-(a::T) where {T<:StateVector} = T(a.basis, -a.data) # FIXME issue #12
 *(a::StateVector, b::Number) = b*a
-copy(a::T) where {T<:StateVector} = T(a.basis, copy(a.data))
-length(a::StateVector) = length(a.basis)::Int
-basis(a::StateVector) = a.basis
+copy(a::T) where {T<:StateVector} = T(a.basis, copy(a.data)) # FIXME issue #12
+length(a::StateVector) = length(a.basis)::Int # FIXME issue #12
+basis(a::StateVector) = a.basis # FIXME issue #12
 directsum(x::StateVector...) = reduce(directsum, x)
 
 # Array-like functions
-Base.size(x::StateVector) = size(x.data)
-@inline Base.axes(x::StateVector) = axes(x.data)
+Base.size(x::StateVector) = size(x.data) # FIXME issue #12
+@inline Base.axes(x::StateVector) = axes(x.data) # FIXME issue #12
 Base.ndims(x::StateVector) = 1
 Base.ndims(::Type{<:StateVector}) = 1
-Base.eltype(x::StateVector) = eltype(x.data)
+Base.eltype(x::StateVector) = eltype(x.data) # FIXME issue #12
 
 # Broadcasting
 Base.broadcastable(x::StateVector) = x
@@ -32,9 +32,9 @@ Base.adjoint(a::StateVector) = dagger(a)
 # Operators
 ##
 
-length(a::AbstractOperator) = length(a.basis_l)::Int*length(a.basis_r)::Int
-basis(a::AbstractOperator) = (check_samebases(a); a.basis_l)
-basis(a::AbstractSuperOperator) = (check_samebases(a); a.basis_l[1])
+length(a::AbstractOperator) = length(a.basis_l)::Int*length(a.basis_r)::Int  # FIXME issue #12
+basis(a::AbstractOperator) = (check_samebases(a); a.basis_l) # FIXME issue #12
+basis(a::AbstractSuperOperator) = (check_samebases(a); a.basis_l[1]) # FIXME issue #12
 
 # Ensure scalar broadcasting
 Base.broadcastable(x::AbstractOperator) = Ref(x)
@@ -60,11 +60,11 @@ Operator exponential.
 """
 exp(op::AbstractOperator) = throw(ArgumentError("exp() is not defined for this type of operator: $(typeof(op)).\nTry to convert to dense operator first with dense()."))
 
-Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r))
+Base.size(op::AbstractOperator) = (length(op.basis_l),length(op.basis_r)) # FIXME issue #12
 function Base.size(op::AbstractOperator, i::Int)
     i < 1 && throw(ErrorException("dimension index is < 1"))
     i > 2 && return 1
-    i==1 ? length(op.basis_l) : length(op.basis_r)
+    i==1 ? length(op.basis_l) : length(op.basis_r) # FIXME issue #12
 end
 
 Base.adjoint(a::AbstractOperator) = dagger(a)

--- a/src/julia_linalg.jl
+++ b/src/julia_linalg.jl
@@ -17,7 +17,7 @@ tr(x::AbstractOperator) = arithmetic_unary_error("Trace", x)
 
 Norm of the given bra or ket state.
 """
-norm(x::StateVector) = norm(x.data)
+norm(x::StateVector) = norm(x.data) # FIXME issue #12
 
 """
     normalize(x::StateVector)
@@ -31,7 +31,7 @@ normalize(x::StateVector) = x/norm(x)
 
 In-place normalization of the given bra or ket so that `norm(x)` is one.
 """
-normalize!(x::StateVector) = (normalize!(x.data); x)
+normalize!(x::StateVector) = (normalize!(x.data); x) # FIXME issue #12
 
 """
     normalize(op)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -1,7 +1,7 @@
-samebases(a::AbstractOperator) = samebases(a.basis_l, a.basis_r)::Bool
-samebases(a::AbstractOperator, b::AbstractOperator) = samebases(a.basis_l, b.basis_l)::Bool && samebases(a.basis_r, b.basis_r)::Bool
-check_samebases(a::Union{AbstractOperator, AbstractSuperOperator}) = check_samebases(a.basis_l, a.basis_r)
-multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_r, b.basis_l)
+samebases(a::AbstractOperator) = samebases(a.basis_l, a.basis_r)::Bool # FIXME issue #12
+samebases(a::AbstractOperator, b::AbstractOperator) = samebases(a.basis_l, b.basis_l)::Bool && samebases(a.basis_r, b.basis_r)::Bool # FIXME issue #12
+check_samebases(a::Union{AbstractOperator, AbstractSuperOperator}) = check_samebases(a.basis_l, a.basis_r) # FIXME issue #12
+multiplicable(a::AbstractOperator, b::AbstractOperator) = multiplicable(a.basis_r, b.basis_l) # FIXME issue #12
 dagger(a::AbstractOperator) = arithmetic_unary_error("Hermitian conjugate", a)
 transpose(a::AbstractOperator) = arithmetic_unary_error("Transpose", a)
 directsum(a::AbstractOperator...) = reduce(directsum, a)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ end
 println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
 
 @doset "sortedindices"
+@doset "bases"
 #VERSION >= v"1.9" && @doset "doctests"
 get(ENV,"JET_TEST","")=="true" && @doset "jet"
 VERSION >= v"1.9" && @doset "aqua"

--- a/test/test_bases.jl
+++ b/test/test_bases.jl
@@ -1,0 +1,55 @@
+using Test
+using QuantumInterface: tensor, ⊗, ptrace, reduced, permutesystems, equal_bases, multiplicable
+using QuantumInterface: GenericBasis, CompositeBasis, NLevelBasis, FockBasis
+
+@testset "basis" begin
+
+shape1 = [5]
+shape2 = [2, 3]
+shape3 = [6]
+
+b1 = GenericBasis(shape1)
+b2 = GenericBasis(shape2)
+b3 = GenericBasis(shape3)
+
+@test b1.shape == shape1
+@test b2.shape == shape2
+@test b1 != b2
+@test b1 != FockBasis(2)
+@test b1 == b1
+
+@test tensor(b1) == b1
+comp_b1 = tensor(b1, b2)
+comp_uni = b1 ⊗ b2
+comp_b2 = tensor(b1, b1, b2)
+@test comp_b1.shape == [prod(shape1), prod(shape2)]
+@test comp_uni.shape == [prod(shape1), prod(shape2)]
+@test comp_b2.shape == [prod(shape1), prod(shape1), prod(shape2)]
+
+@test b1^3 == CompositeBasis(b1, b1, b1)
+@test (b1⊗b2)^2 == CompositeBasis(b1, b2, b1, b2)
+@test_throws ArgumentError b1^(0)
+
+comp_b1_b2 = tensor(comp_b1, comp_b2)
+@test comp_b1_b2.shape == [prod(shape1), prod(shape2), prod(shape1), prod(shape1), prod(shape2)]
+@test comp_b1_b2 == CompositeBasis(b1, b2, b1, b1, b2)
+
+@test_throws ArgumentError tensor()
+@test comp_b2.shape == tensor(b1, comp_b1).shape
+@test comp_b2 == tensor(b1, comp_b1)
+
+@test_throws ArgumentError ptrace(comp_b1, [1, 2])
+@test ptrace(comp_b2, [1]) == ptrace(comp_b2, [2]) == comp_b1 == ptrace(comp_b2, 1)
+@test ptrace(comp_b2, [1, 2]) == ptrace(comp_b1, [1])
+@test ptrace(comp_b2, [2, 3]) == ptrace(comp_b1, [2])
+@test ptrace(comp_b2, [2, 3]) == reduced(comp_b2, [1])
+@test_throws ArgumentError reduced(comp_b1, [])
+
+comp1 = tensor(b1, b2, b3)
+comp2 = tensor(b2, b1, b3)
+@test permutesystems(comp1, [2,1,3]) == comp2
+
+@test !equal_bases([b1, b2], [b1, b3])
+@test !multiplicable(comp1, b1 ⊗ b2 ⊗ NLevelBasis(prod(b3.shape)))
+
+end # testset


### PR DESCRIPTION
In preparation of more significant changes to the basis interface and abstract types being discussed across #12 #25 #26 #27 #33 #34 #35 #36 this PR adds the `test_bases` from `QuantumOpticsBase`, moves all the `show` methods to their own file, and does a little more reorganization. No logic should be affected with this change.