### PR TITLE
Introducing metrics into the interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # News
 
+## v0.3.8 - 2025-03-08
+- Introduce `metrics.jl` file for metric declarations.
+
 ## v0.3.7 - 2025-01-16
 
 - Migrate `express` functionalities and representation types from QuantumSymbolics.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -85,6 +85,15 @@ function squeeze end
 
 function wigner end
 
+##
+# Metrics
+##
+
+function entropy_vn end
+
+function fidelity end
+
+function logarithmic_negativity end
 
 include("bases.jl")
 include("abstract_types.jl")

--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -85,16 +85,6 @@ function squeeze end
 
 function wigner end
 
-##
-# Metrics
-##
-
-function entropy_vn end
-
-function fidelity end
-
-function logarithmic_negativity end
-
 include("bases.jl")
 include("abstract_types.jl")
 
@@ -110,5 +100,7 @@ include("sparse.jl")
 
 include("sortedindices.jl")
 include("express.jl")
+
+include("metrics.jl")
 
 end # module

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,0 +1,38 @@
+"""
+Calculate the Von Neumann entropy of a density operator, defined as
+
+```math
+S(\\rho) = -Tr(\\rho \\log(\\rho))
+```
+
+wherein it is understood that ``0 \\log(0) \\equiv 0``.
+
+Consult specific implementation for function arguments and logarithmic basis.
+"""
+function entropy_vn end
+
+"""
+Calculate the joint fidelity of two density operators, defined as
+
+```math
+F(\\rho, \\sigma) = Tr(\\sqrt{\\sqrt{\\rho} \\sigma \\sqrt{\\rho}}).
+```
+
+Consult specific implementation for function arguments.
+"""
+function fidelity end
+
+"""
+Calculate the logarithmic negativity of a density operator partition, defined as
+
+```math
+N(\\rho) = \\log\\|\\rho^{T_B}\\|_1
+```
+
+wherein ``\\rho^{T_B}`` denotes partial transposition as per the partition and
+``\\|\\bullet\\|_1`` is the trace norm.
+
+
+Consult specific implementation for function arguments and logarithmic basis.
+"""
+function logarithmic_negativity end


### PR DESCRIPTION
These metrics are introduced into the interface for enhancing uniformity between the various packages that may choose to implement their dispatch.