### PR TITLE
Resolving issue related to QuantumOpticsBase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # News
 
+## v0.3.9 - 2025-03-23
+- Resolve issue with `QuantumOpticsBase.jl` implementation of `entropy_vn`.
+
 ## v0.3.8 - 2025-03-08
 - Introduce `metrics.jl` file for metric declarations.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -10,7 +10,8 @@ wherein it is understood that ``0 \\log(0) \\equiv 0``.
 Consult specific implementation for function arguments and logarithmic basis.
 """
 function entropy_vn end
-
+# avoids causing a breaking change in QuantumOpticsBase.jl
+entropy_vn(::StateVector; kwargs...) = 0
 """
 Calculate the joint fidelity of two density operators, defined as
 


### PR DESCRIPTION
Moved a trivial definition of `entropy_vn` relating to pure states directly to the interface. Consult [this PR](https://github.com/qojulia/QuantumOpticsBase.jl/pull/185) for further details.
@Krastanov