### PR TITLE
Introduce `GabsRepr` for future work in QuantumSymbolics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.3.9 - 2025-04-08
+
+- Add `GabsRepr` type for representations in Gabs.
+
 ## v0.3.8 - 2025-03-08
 - Introduce `metrics.jl` file for metric declarations.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/express.jl
+++ b/src/express.jl
@@ -30,3 +30,7 @@ end
 struct QuantumMCRepr <: AbstractRepresentation end
 """Representation using tableaux governed by `QuantumClifford.jl`"""
 struct CliffordRepr <: AbstractRepresentation end
+"""Representation using Gaussian phase space formalism governed by `Gabs.jl`."""
+struct GabsRepr{B} <: AbstractRepresentation 
+    basis::B
+end


### PR DESCRIPTION
My current plan for the `express` symbolic-to-numerics conversion is something along the lines of
```
express(CoherentState(α), GabsRepr(QuadBlockBasis(nmodes)) -> Gabs.coherentstate(QuadBlockBasis(nmodes), α)
```
where the symplectic basis (in this case `QuadBlockBasis(nmodes)`) must be defined inside the `GabsRepr` composite type. 

There might be opposition to the field name `.basis` for `GabsRepr`, given the discussion in #35. I'm in favor of it because `.basis` fields are present in several Gabs types to represent the symplectic basis, including `GaussianState`, `GaussianUnitary`, and `GaussianChannel`. It's kind of a developer headache though, as for instance, `CoherentState` is currently defined in QSymbolics as follows:
```
"""Coherent state in defined Fock basis."""
@withmetadata struct CoherentState <: SpecialKet
    alpha::Number # TODO parameterize
    basis::FockBasis
end
CoherentState(alpha::Number) = CoherentState(alpha, inf_fock_basis)
```
So under the hood, both `CoherentState` and `GabsRepr` have the same field name `.basis`, even though they really correspond to different notions (the former really being a space and the latter is a symplectic basis).

However, this might not be too confusing from a user perspective, as there's no reason that I'm aware of where you should specify a Fock cutoff basis for a symbolic object. When we do numerical translations to QuantumOptics with `QuantumOpticsRepr`, the corresponding field `.cutoff` is specified anyways. In other words, the appropriate symbolic-to-numerics workflow is to define `CoherentState(α)`, then be concerned with bases and spaces with the relevant `AbstractRepresentation` subtype. If we *want* to address this conflation, here's a couple things we could do:
- Rename the `.basis` field in `GabsRepr` to something like `.sympbasis`, which would be a different name than the `.basis` fields in several Gabs types.
- Open up the `.basis` field in `CoherentState` so that it can accept symplectic basis types from Gabs in addition to the Fock cutoff basis `FockBasis`. That could get messy in several different ways and I don't recommend this approach.

@Krastanov @akirakyle

