### PR TITLE
Introduce Hilbert space interface

### DIFF
--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -87,6 +87,7 @@ function wigner end
 
 include("bases.jl")
 include("abstract_types.jl")
+include("spaces.jl")
 
 include("linalg.jl")
 include("tensor.jl")

--- a/src/spaces.jl
+++ b/src/spaces.jl
@@ -1,0 +1,137 @@
+"""
+Abstract Hilbert space class for all specialized Hilbert spaces.
+"""
+abstract type AbstractHilbertSpace end
+
+"""
+    space(a)
+
+Return the Hilbert space of an object.
+"""
+function space end
+
+"""
+    HilbertSpace(shape)
+
+Hilbert space of a single quantum system, whose dimension is given by `shape`.
+
+A Hilbert space of a quantum system with finite (infinite) degrees of freedom has 
+finite (infinite) dimension. See https://en.wikipedia.org/wiki/Quantum_state_space 
+for mathematical details.
+
+For example, the Hilbert space of a single spin-1/2 particle is
+`HilbertSpace(2)`. The Hilbert space for a single quantum harmonic oscillator
+mode is `HilbertSpace(Inf)`.
+"""
+struct HilbertSpace{S} <: AbstractHilbertSpace 
+    shape::S
+end
+Base.:(==)(s1::HilbertSpace, s2::HilbertSpace) = s1.shape == s2.shape
+Base.length(space::HilbertSpace) = space.shape
+
+"""
+    CompositeHilbertSpace(s1, s2...)
+
+Hilbert space for a composite system of quantum objects with individual Hilbert spaces,
+whose dimensions [s1.shape, s2.shape...] are contained in `shape` and Hilbert space objects 
+[s1, s2...] are contained in `spaces`.
+
+For example, the composite Hilbert space of a spin-1/2 particle coupled to a quantum
+harmonic oscillator mode is `HilbertSpace(2) ⊗ HilbertSpace(Inf)`, which returns
+a `CompositeHilbertSpace([2, Inf], [HilbertSpace(2), HilbertSpace(Inf)])` object.
+"""
+struct CompositeHilbertSpace{S,H} <: AbstractHilbertSpace
+    shape::S
+    spaces::H
+end
+CompositeHilbertSpace(spaces) = CompositeHilbertSpace([length(s) for s ∈ spaces], spaces)
+CompositeHilbertSpace(spaces::HilbertSpace...) = CompositeHilbertSpace((spaces...,))
+CompositeHilbertSpace(spaces::Vector) = CompositeHilbertSpace(spaces...)
+
+Base.:(==)(s1::CompositeHilbertSpace, s2::CompositeHilbertSpace) = all(i == j for (i, j) in zip(s1.spaces, s2.spaces))
+
+"""
+    tensor(x::HilbertSpace, y::HilbertSpace, z::HilbertSpace...)
+
+Create a [`CompositeHilbertSpace`](@ref) from the given Hilbert spaces.
+
+Any given `CompositeHilbertSpace` is expanded so that the resulting `CompositeHilbertSpace` never
+contains another `CompositeHilbertSpace`.
+"""
+tensor(s1::HilbertSpace, s2::HilbertSpace) = CompositeHilbertSpace([length(s1), length(s2)], (s1, s2))
+tensor(s1::CompositeHilbertSpace, s2::CompositeHilbertSpace) = CompositeHilbertSpace(vcat(s1.shape..., s2.shape...), vcat(s1.spaces..., s2.spaces...))
+function tensor(s1::CompositeHilbertSpace, s2::HilbertSpace)
+    shape = vcat(s1.shape, length(s2))
+    spaces = vcat(s1.spaces..., s2)
+    CompositeHilbertSpace(shape, spaces)
+end
+function tensor(s1::HilbertSpace, s2::CompositeHilbertSpace)
+    shape = vcat(length(s1), s2.shape)
+    spaces = vcat(s1, s2.spaces...)
+    CompositeHilbertSpace(shape, spaces)
+end
+tensor(spaces::T...) where {T<:AbstractHilbertSpace} = reduce(tensor, spaces)
+tensor(space::T) where {T<:AbstractHilbertSpace} = space
+
+function Base.:^(space::T, N::Integer) where {T<:AbstractHilbertSpace}
+    if N < 1
+        throw(ArgumentError("Power of a Hilbert space is only defined for positive integers."))
+    end
+    tensor([space for i=1:N]...)
+end
+
+"""
+Exception that should be raised for an illegal algebraic operation between quantum objects
+with different Hilbert spaces.
+"""
+mutable struct IncompatibleSpaces <: Exception end
+
+"""
+    samespaces(a, b)
+
+Test if two objects have the same Hilbert spaces.
+"""
+samespaces(s1::AbstractHilbertSpace, s2::AbstractHilbertSpace) = s1 == s2
+
+"""
+    check_samespaces(a, b)
+
+Throw an [`IncompatibleSpaces`](@ref) error if the objects don't have
+the same Hilbert spaces.
+"""
+check_samespaces(s1::AbstractHilbertSpace, s2::AbstractHilbertSpace) = samespaces(s1, s2) || throw(IncompatibleSpaces())
+
+function ptrace(space::CompositeHilbertSpace, indices)
+    J = [i for i in 1:length(space.spaces) if i ∉ indices]
+    length(J) > 0 || throw(ArgumentError("Tracing over all indices is not allowed in `ptrace`."))
+    return reduced(space, J)
+end
+function reduced(space::CompositeHilbertSpace, indices)
+    if length(indices)==0
+        throw(ArgumentError("At least one subsystem must be specified in reduced."))
+    elseif length(indices)==1
+        return space.spaces[indices[1]]
+    else
+        return CompositeHilbertSpace(space.shape[indices], space.spaces[indices])
+    end
+end
+
+
+##
+# show methods
+##
+
+function show(io::IO, x::HilbertSpace)
+    print(io, "HilbertSpace(shape=$(x.shape))")
+end
+
+function show(io::IO, x::CompositeHilbertSpace)
+    print(io, "[")
+    @inbounds for i in 1:length(x.spaces)
+        print(io, x.spaces[i])
+        if i != length(x.spaces)
+            print(io, " ⊗ ")
+        end
+    end
+    print(io, "]")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ end
 println("Starting tests with $(Threads.nthreads()) threads out of `Sys.CPU_THREADS = $(Sys.CPU_THREADS)`...")
 
 @doset "sortedindices"
+@doset "spaces"
 #VERSION >= v"1.9" && @doset "doctests"
 get(ENV,"JET_TEST","")=="true" && @doset "jet"
 VERSION >= v"1.9" && @doset "aqua"

--- a/test/test_spaces.jl
+++ b/test/test_spaces.jl
@@ -1,0 +1,32 @@
+using Test
+using QuantumInterface
+import QuantumInterface: ⊗
+
+s = QuantumInterface
+
+hs2 = s.HilbertSpace(2)
+hsinf = s.HilbertSpace(Inf)
+tp = s.CompositeHilbertSpace([2, Inf], [s.HilbertSpace(2), s.HilbertSpace(Inf)])
+
+@test length(hs2) == 2 && length(hsinf) == Inf
+@test hs2 ⊗ hsinf == tp
+@test s.CompositeHilbertSpace(hs2, hsinf) == tp
+@test s.CompositeHilbertSpace((hs2, hsinf)) == tp
+@test s.CompositeHilbertSpace([hs2, hsinf]) == tp
+
+@test tp ⊗ hs2 == s.CompositeHilbertSpace([2, Inf, 2], [hs2, hsinf, hs2])
+@test hs2 ⊗ tp == s.CompositeHilbertSpace([2, 2, Inf], [hs2, hs2, hsinf])
+@test tp ⊗ tp == s.CompositeHilbertSpace([2, Inf, 2, Inf], [hs2, hsinf, hs2, hsinf])
+@test tp ⊗ hs2 ⊗ tp == s.CompositeHilbertSpace([2, Inf, 2, 2, Inf], [hs2, hsinf, hs2, hs2, hsinf])
+@test s.tensor(tp) == tp
+
+@test_throws ArgumentError hs2^0
+@test hs2^3 == hs2 ⊗ hs2 ⊗ hs2
+
+@test s.check_samespaces(hs2, hs2) == true
+@test_throws s.IncompatibleSpaces s.check_samespaces(hs2, hsinf)
+
+@test s.ptrace(tp, 2) == hs2
+@test_throws ArgumentError s.ptrace(tp, [1, 2])
+@test_throws ArgumentError s.reduced(tp, [])
+@test s.ptrace(hs2 ⊗ hsinf ⊗ hsinf ⊗ hs2, [2, 4]) == hs2 ⊗ hsinf


### PR DESCRIPTION
See #35 and #50 for discussions regarding the conflation of basis vs. space. This PR introduces an `AbstractHilbertSpace` interface that will be used downstream in QuantumSymbolics in place of the basis types used in QuantumOptics. Initially, as remarked in #50, my plan was to define `ContinuousHilbertSpace` and `DiscreteHilbertSpace` structs for continuous variable and discrete variable quantum systems, respectively, but the only thing distinguishing them (under the hood) was the following base definition:
```
Base.length(::ContinuousHilbertSpace) = Inf
Base.length(x::DiscreteHilbertSpace) = x.shape
```
To combine these two notions more cleanly, I decided to simply have the `HilbertSpace` type:
```
"""
    HilbertSpace(shape)

Hilbert space of a single quantum system, whose dimension is given by `shape`.

A Hilbert space of a quantum system with finite (infinite) degrees of freedom has 
finite (infinite) dimension. See https://en.wikipedia.org/wiki/Quantum_state_space 
for mathematical details.

For example, the Hilbert space of a single spin-1/2 particle is
`HilbertSpace(2)`. The Hilbert space for a single quantum harmonic oscillator
mode is `HilbertSpace(Inf)`.
"""
struct HilbertSpace{S} <: AbstractHilbertSpace 
    shape::S
end
```
Then, tensor products of Hilbert spaces can of course be called with `⊗` to create a `CompositeHilbertSpace` type, similar to how `CompositeBasis` is defined with `Basis` subtypes. Relevant methods and types are defined for Hilbert space equality checks, incompatibility errors, partial traces, `Base.show`, etc.

Anyone reading this PR is free to pick it apart as much as they want. My current opinion is that knowledge about Hilbert space dimension is all that is required for symbolic quantum object types in QuantumSymbolics. Underlying basis information is only relevant for numerical calculations, hence it should only be defined (in the scope of QuantumSymbolics) when using the appropriate `AbstractRepresentation` subtype in symbolic-to-numerical translations with `express`. Importantly, this cleaner Hilbert space interface will be implemented in QuantumSymbolics to deal with its growing ecosystem of quantum numerical backends, yet it can easily manage the specifics of the basis interface in QuantumOptics.

One lingering thing is that we should probably define a `defaultbasis` method for the `AbstractHilbertSpace` subtypes, e.g.,
```
defaultbasis(HilbertSpace(2)) == SpinBasis(1//2)
```
For infinite-dimensional Hilbert spaces, obviously the default basis should be `FockBasis`, yet how do we decide the Fock cutoff value? Do we just set it to `Inf` as well? Is that helpful at all?

@krastanov @akirakyle @amilsted @david-pl