### PR TITLE
Deprecate `PauliBasis`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.3.10 - 2025-04-21
+
+- Deprecate `PauliBasis` as it is identical to `SpinBasis(1//2)^N` but without the compatibility with `CompositeBasis`.
+
 ## v0.3.9 - 2025-04-20
 
 - Implement general `tensor_pow` via `power_by_squaring`

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -283,25 +283,6 @@ Base.:(==)(b1::NLevelBasis, b2::NLevelBasis) = b1.N == b2.N
 
 
 """
-    PauliBasis(num_qubits::Int)
-
-Basis for an N-qubit space where `num_qubits` specifies the number of qubits.
-The dimension of the basis is 2²ᴺ.
-"""
-struct PauliBasis{S,B} <: Basis
-    shape::S
-    bases::B
-    function PauliBasis(num_qubits::T) where {T<:Integer}
-        shape = [2 for _ in 1:num_qubits]
-        bases = Tuple(SpinBasis(1//2) for _ in 1:num_qubits)
-        return new{typeof(shape),typeof(bases)}(shape, bases)
-    end
-end
-
-Base.:(==)(pb1::PauliBasis, pb2::PauliBasis) = length(pb1.bases) == length(pb2.bases)
-
-
-"""
     SpinBasis(n)
 
 Basis for spin-n particles.

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -10,3 +10,17 @@ function equal_bases(a, b)
     end
     return true
 end
+
+struct PauliBasis{S,B} <: Basis
+    shape::S
+    bases::B
+    function PauliBasis(num_qubits::T) where {T<:Integer}
+        Base.depwarn("`PauliBasis` will be removed in future versions as it does not represent the Pauli operator basis. SpinBasis(1//2)^N or NLevelBasis(2)^N should likely be used instead.", :PauliBasis)
+        shape = [2 for _ in 1:num_qubits]
+        bases = Tuple(SpinBasis(1//2) for _ in 1:num_qubits)
+        return new{typeof(shape),typeof(bases)}(shape, bases)
+    end
+end
+
+Base.:(==)(pb1::PauliBasis, pb2::PauliBasis) = length(pb1.bases) == length(pb2.bases)
+


### PR DESCRIPTION
Applies on top of #41. Closes #36. See #39 for more discussion.

I think eventual removal of `PauliBasis` rather than deprecation with renaming makes the most sense. This is because it is identical to `SpinBasis(1//2)^N`, however with the sever downside that it is not compatible with any of the `CompositeBasis` machinery such as `reduced`, `ptrace`, `embed`, `permutesystems`, etc...