### PR TITLE
Change `@assert` to `ArgumentError`

### DIFF
--- a/src/bases.jl
+++ b/src/bases.jl
@@ -255,8 +255,8 @@ For a permutation vector `[2,1,3]` and a given object with basis `[b1, b2, b3]`
 this function results in `[b2, b1, b3]`.
 """
 function permutesystems(b::CompositeBasis, perm)
-    @assert length(b.bases) == length(perm)
-    @assert isperm(perm)
+    (nsubsystems(b) == length(perm)) || throw(ArgumentError("Must have nsubsystems(b) == length(perm) in permutesystems"))
+    isperm(perm) || throw(ArgumentError("Must pass actual permeutation to permutesystems"))
     CompositeBasis(b.shape[perm], b.bases[perm])
 end
 
@@ -278,7 +278,7 @@ struct FockBasis{T} <: Basis
     offset::T
     function FockBasis(N::T,offset::T=0) where T
         if N < 0 || offset < 0 || N <= offset
-            throw(DimensionMismatch())
+            throw(ArgumentError("Fock cutoff and offset must be positive and cutoff must be less than offset"))
         end
         new{T}([N-offset+1], N, offset)
     end
@@ -296,9 +296,7 @@ struct NLevelBasis{T} <: Basis
     shape::Vector{T}
     N::T
     function NLevelBasis(N::T) where T<:Integer
-        if N < 1
-            throw(DimensionMismatch())
-        end
+        N > 0 || throw(ArgumentError("N must be greater than 0"))
         new{T}([N], N)
     end
 end
@@ -340,8 +338,8 @@ struct SpinBasis{S,T} <: Basis
     function SpinBasis{S}(spinnumber::Rational{T}) where {S,T<:Integer}
         n = numerator(spinnumber)
         d = denominator(spinnumber)
-        @assert d==2 || d==1
-        @assert n >= 0
+        d==2 || d==1 || throw(ArgumentError("Can only construct integer or half-integer spin basis"))
+        n >= 0 || throw(ArgumentError("Can only construct positive spin basis"))
         N = numerator(spinnumber*2 + 1)
         new{spinnumber,T}([N], spinnumber)
     end

--- a/src/embed_permute.jl
+++ b/src/embed_permute.jl
@@ -7,7 +7,7 @@ specifies in which subsystems the corresponding operator is defined.
 """
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
                operators::Dict{<:Vector{<:Integer}, T}) where T<:AbstractOperator
-    @assert length(basis_l.bases) == length(basis_r.bases)
+    (nsubsystems(basis_l) == nsubsystems(basis_r)) || throw(ArgumentError("Must have nsubsystems(bl) == nsubsystems(br) in embed"))
     N = length(basis_l.bases)::Int # type assertion to help type inference
     if length(operators) == 0
         return identityoperator(T, basis_l, basis_r)
@@ -55,11 +55,11 @@ Tensor product of operators where missing indices are filled up with identity op
 function embed(basis_l::CompositeBasis, basis_r::CompositeBasis,
                indices, operators::Vector{T}) where T<:AbstractOperator
 
-    @assert check_embed_indices(indices)
+    check_embed_indices(indices) || throw(ArgumentError("Must have unique indices in embed"))
+    (nsubsystems(basis_l) == nsubsystems(basis_r)) || throw(ArgumentError("Must have nsubsystems(bl) == nsubsystems(br) in embed"))
+    (length(indices) == length(operators)) || throw(ArgumentError("Must have length(indices) == length(operators) in embed"))
 
-    N = length(basis_l.bases)
-    @assert length(basis_r.bases) == N
-    @assert length(indices) == length(operators)
+    N = nsubsystems(basis_l)
 
     # Embed all single-subspace operators.
     idxop_sb = [x for x in zip(indices, operators) if x[1] isa Integer]

--- a/src/sortedindices.jl
+++ b/src/sortedindices.jl
@@ -74,9 +74,9 @@ function check_indices(imax, indices)
     N = length(indices)
     for n=1:N
         i = indices[n]
-        @assert 0 < i <= imax
+        (0 < i <= imax) || throw(ArgumentError("indices exceed allowable range"))
         for m in n+1:N
-            @assert i != indices[m]
+            (i != indices[m]) || throw(ArgumentError("indices not unique"))
         end
     end
 end
@@ -90,10 +90,10 @@ function check_sortedindices(imax, indices)
         return nothing
     end
     i_ = indices[1]
-    @assert 0 < i_ <= imax
+    (0 < i_ <= imax) || throw(ArgumentError("indices exceed allowable range"))
     for i in indices[2:end]
-        @assert 0 < i <= imax
-        @assert i > i_
+        (0 < i <= imax) || throw(ArgumentError("indices exceed allowable range"))
+        (i > i_) || throw(ArgumentError("indices not sorted"))
     end
 end
 
@@ -107,8 +107,7 @@ function check_embed_indices(indices)
     # short circuit return when `indices` is empty.
     length(indices) == 0 && return true
 
-    err_str = "Variable `indices` comes in an unexpected form. Expecting `Array{Union{Int, Array{Int, 1}}, 1}`"
-    @assert all(x isa Array || x isa Int for x in indices) err_str
+    all(x isa Array || x isa Int for x in indices) || throw(ArgumentError("Variable `indices` comes in an unexpected form. Expecting `Array{Union{Int, Array{Int, 1}}, 1}`"))
 
     # flatten the indices and check for uniqueness
     # use a custom flatten because it's ≈ 4x  faster than Base.Iterators.flatten

--- a/test/test_sortedindices.jl
+++ b/test/test_sortedindices.jl
@@ -18,15 +18,15 @@ x = [3, 5]
 s.reducedindices!(x, [2, 3, 5, 6])
 @test x == [2, 3]
 
-@test_throws AssertionError s.check_indices(5, [1, 6])
-@test_throws AssertionError s.check_indices(5, [0, 2])
+@test_throws ArgumentError s.check_indices(5, [1, 6])
+@test_throws ArgumentError s.check_indices(5, [0, 2])
 @test s.check_indices(5, Int[]) == nothing
 @test s.check_indices(5, [1, 3]) == nothing
 @test s.check_indices(5, [3, 1]) == nothing
 
-@test_throws AssertionError s.check_sortedindices(5, [1, 6])
-@test_throws AssertionError s.check_sortedindices(5, [3, 1])
-@test_throws AssertionError s.check_sortedindices(5, [0, 2])
+@test_throws ArgumentError s.check_sortedindices(5, [1, 6])
+@test_throws ArgumentError s.check_sortedindices(5, [3, 1])
+@test_throws ArgumentError s.check_sortedindices(5, [0, 2])
 @test s.check_sortedindices(5, Int[]) == nothing
 @test s.check_sortedindices(5, [1, 3]) == nothing
 


### PR DESCRIPTION
Assertions should only be used to check for conditions that are logically impossible to happen and should not be relied upon to always be called (see [docs](https://docs.julialang.org/en/v1/base/base/#Base.@assert)).

Note this breaks a few downstream tests in QuantumOpticsBase and https://github.com/qojulia/QuantumOpticsBase.jl/pull/190 fixes them