### PR TITLE
Implement general `tensor_pow` via `Base.power_by_squaring`

### DIFF
--- a/src/QuantumInterface.jl
+++ b/src/QuantumInterface.jl
@@ -45,7 +45,7 @@ function tensor end
 const ⊗ = tensor
 tensor() = throw(ArgumentError("Tensor function needs at least one argument."))
 
-function tensor_pow end # TODO should Base.^ be the same as tensor_pow?
+function tensor_pow end
 
 function traceout! end
 

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -93,12 +93,9 @@ function tensor(b1::Basis, b2::CompositeBasis)
 end
 tensor(bases::Basis...) = reduce(tensor, bases)
 
-function Base.:^(b::Basis, N::Integer)
-    if N < 1
-        throw(ArgumentError("Power of a basis is only defined for positive integers."))
-    end
-    tensor([b for i=1:N]...)
-end
+Base.convert(::Type{CompositeBasis{B,S}}, b) where {B,S} = CompositeBasis([b])
+Base.:*(b1::Basis, b2::Basis) = tensor(b1,b2)
+Base.:^(b::Basis, N::Integer) = tensor_pow(b, N)
 
 """
     equal_shape(a, b)

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -93,8 +93,6 @@ function tensor(b1::Basis, b2::CompositeBasis)
 end
 tensor(bases::Basis...) = reduce(tensor, bases)
 
-Base.convert(::Type{CompositeBasis{B,S}}, b) where {B,S} = CompositeBasis([b])
-Base.:*(b1::Basis, b2::Basis) = tensor(b1,b2)
 Base.:^(b::Basis, N::Integer) = tensor_pow(b, N)
 
 """

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -8,3 +8,10 @@ tensor(op::AbstractOperator) = op
 tensor(operators::AbstractOperator...) = reduce(tensor, operators)
 tensor(state::StateVector) = state
 tensor(states::Vector{T}) where T<:StateVector = reduce(tensor, states)
+
+"""
+    tensor_pow(a, N)
+
+Gives the tensor product of `a` `N` times.
+"""
+tensor_pow(a, N) = Base.power_by_squaring(a, N; mul=⊗)

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -14,4 +14,30 @@ tensor(states::Vector{T}) where T<:StateVector = reduce(tensor, states)
 
 Gives the tensor product of `a` `N` times.
 """
-tensor_pow(a, N) = Base.power_by_squaring(a, N; mul=⊗)
+tensor_pow(a, N) = tensor_pow_by_squaring(a, N)
+
+# Copied from Base.power_by_squaring as `mul` keyword dosn't work without implementing `*`
+function tensor_pow_by_squaring(x, p::Integer)
+    if p == 1
+        return x
+    elseif p == 2
+        return tensor(x, x)
+    elseif p < 1
+        throw(DomainError("Cannot take tensor_pow to power less than one"))
+    end
+    t = trailing_zeros(p) + 1
+    p >>= t
+    while (t -= 1) > 0
+        x = tensor(x, x)
+    end
+    y = x
+    while p > 0
+        t = trailing_zeros(p) + 1
+        p >>= t
+        while (t -= 1) >= 0
+            x = tensor(x, x)
+        end
+        y = tensor(y, x)
+    end
+    return y
+end

--- a/test/test_bases.jl
+++ b/test/test_bases.jl
@@ -28,7 +28,7 @@ comp_b2 = tensor(b1, b1, b2)
 
 @test b1^3 == CompositeBasis(b1, b1, b1)
 @test (b1⊗b2)^2 == CompositeBasis(b1, b2, b1, b2)
-@test_throws ArgumentError b1^(0)
+@test_throws DomainError b1^(0)
 
 comp_b1_b2 = tensor(comp_b1, comp_b2)
 @test comp_b1_b2.shape == [prod(shape1), prod(shape2), prod(shape1), prod(shape1), prod(shape2)]


### PR DESCRIPTION
I was wanting a fast `tensor_pow` on operators for my ongoing superoperator work and realized it can be implemented generally here. `tensor_pow` currently isn't used anywhere in `qojulia` but is used in QuantumClifford [here](https://github.com/QuantumSavory/QuantumClifford.jl/blob/cef3b95eb94ef1abd952747c5f4217581d78d41d/src/linalg.jl#L239). This should improve upon the implementation there from `O(N)` to `O(log(N))`.

Also `Base.^` is already defined for `AbstractOperator` [here](https://github.com/qojulia/QuantumInterface.jl/blob/46223c3d31313d6b5e89dd335796d504360cc76e/src/julia_base.jl#L54) so perhaps it is alright to remove the TODO?