### PR TITLE
Migrate `PositionBasis` and `MomentumBasis` from QuantumOpticsBase.jl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # News
 
+#
+
 ## v0.3.10 - 2025-04-21
 
 - Deprecate `PauliBasis` as it is identical to `SpinBasis(1//2)^N` but without the compatibility with `CompositeBasis`.

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -308,6 +308,72 @@ SpinBasis(spinnumber) = SpinBasis(convert(Rational{Int}, spinnumber))
 
 Base.:(==)(b1::SpinBasis, b2::SpinBasis) = b1.spinnumber==b2.spinnumber
 
+abstract type ParticleBasis <: Basis end
+
+"""
+    PositionBasis(xmin, xmax, Npoints)
+    PositionBasis(b::MomentumBasis)
+
+Basis for a particle in real space.
+
+For simplicity periodic boundaries are assumed which means that
+the rightmost point defined by `xmax` is not included in the basis
+but is defined to be the same as `xmin`.
+
+When a [`MomentumBasis`](@ref) is given as argument the exact values
+of ``x_{min}`` and ``x_{max}`` are due to the periodic boundary conditions
+more or less arbitrary and are chosen to be
+``-\\pi/dp`` and ``\\pi/dp`` with ``dp=(p_{max}-p_{min})/N``.
+"""
+struct PositionBasis{X1,X2,T,F} <: ParticleBasis
+    shape::Vector{T}
+    xmin::F
+    xmax::F
+    N::T
+    function PositionBasis{X1,X2}(xmin::F, xmax::F, N::T) where {X1,X2,F,T<:Integer}
+        @assert isa(X1, Real) && isa(X2, Real)
+        new{X1,X2,T,F}([N], xmin, xmax, N)
+    end
+end
+function PositionBasis(xmin::F1, xmax::F2, N) where {F1,F2}
+    F = promote_type(F1,F2)
+    return PositionBasis{xmin,xmax}(convert(F,xmin),convert(F,xmax),N)
+end
+
+"""
+    MomentumBasis(pmin, pmax, Npoints)
+    MomentumBasis(b::PositionBasis)
+
+Basis for a particle in momentum space.
+
+For simplicity periodic boundaries are assumed which means that
+`pmax` is not included in the basis but is defined to be the same as `pmin`.
+
+When a [`PositionBasis`](@ref) is given as argument the exact values
+of ``p_{min}`` and ``p_{max}`` are due to the periodic boundary conditions
+more or less arbitrary and are chosen to be
+``-\\pi/dx`` and ``\\pi/dx`` with ``dx=(x_{max}-x_{min})/N``.
+"""
+struct MomentumBasis{P1,P2,T,F} <: ParticleBasis
+    shape::Vector{T}
+    pmin::F
+    pmax::F
+    N::T
+    function MomentumBasis{P1,P2}(pmin::F, pmax::F, N::T) where {T<:Integer,F,P1,P2}
+        @assert isa(P1, Real) && isa(P2, Real)
+        new{P1,P2,T,F}([N], pmin, pmax, N)
+    end
+end
+function MomentumBasis(pmin::F1, pmax::F2, N) where {F1,F2}
+    F = promote_type(F1,F2)
+    return MomentumBasis{pmin,pmax}(convert(F,pmin), convert(F,pmax), N)
+end
+
+PositionBasis(b::MomentumBasis) = (dp = (b.pmax - b.pmin)/b.N; PositionBasis(-pi/dp, pi/dp, b.N))
+MomentumBasis(b::PositionBasis) = (dx = (b.xmax - b.xmin)/b.N; MomentumBasis(-pi/dx, pi/dx, b.N))
+
+==(b1::PositionBasis, b2::PositionBasis) = b1.xmin==b2.xmin && b1.xmax==b2.xmax && b1.N==b2.N
+==(b1::MomentumBasis, b2::MomentumBasis) = b1.pmin==b2.pmin && b1.pmax==b2.pmax && b1.N==b2.N
 
 """
     SumBasis(b1, b2...)
@@ -397,6 +463,14 @@ end
 
 function show(stream::IO, x::NLevelBasis)
     write(stream, "NLevel(N=$(x.N))")
+end
+
+function show(stream::IO, x::PositionBasis)
+    write(stream, "Position(xmin=$(x.xmin), xmax=$(x.xmax), N=$(x.N))")
+end
+
+function show(stream::IO, x::MomentumBasis)
+    write(stream, "Momentum(pmin=$(x.pmin), pmax=$(x.pmax), N=$(x.N))")
 end
 
 function show(stream::IO, x::SumBasis)


### PR DESCRIPTION
See note in https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/113#issue-3054813653. These basis types will be used in QuantumSymbolics.jl.