### PR TITLE
Define `tensor(states::StateVector...) = reduce(tensor, states)` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.1 - 2025-06-06
+
+- Define `tensor(states::StateVector...) = reduce(tensor, states)` method.
+
 ## v0.4.0 - 2025-06-04
 
 - **(breaking)** Move methods which access a `.data` field but are defined only on an abstract types to QuantumOpticsBase

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/tensor.jl
+++ b/src/tensor.jl
@@ -7,6 +7,7 @@ tensor(a::AbstractOperator, b::AbstractOperator) = arithmetic_binary_error("Tens
 tensor(op::AbstractOperator) = op
 tensor(operators::AbstractOperator...) = reduce(tensor, operators)
 tensor(state::StateVector) = state
+tensor(states::StateVector...) = reduce(tensor, states)
 tensor(states::Vector{T}) where T<:StateVector = reduce(tensor, states)
 
 """


### PR DESCRIPTION
Very small addition, but it's something needed to avoid a couple of failing tests in my incoming Gabs-QSymbolics integration PR.