### PR TITLE
Add lazy option to QuantumOpticsRepr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.3 - 2026-06-04
+
+- Add a `lazy::Bool=false` option to `QuantumOpticsRepr`. The existing `QuantumOpticsRepr()` and `QuantumOpticsRepr(cutoff)` constructors are preserved.
+
 ## v0.4.2 - 2025-11-29
 
 - Define `commutator` and `anticommutator`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/express.jl
+++ b/src/express.jl
@@ -22,10 +22,18 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 # Commonly used representations -- interfaces for each one defined in separate packages
 ##
 
-"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`."""
-Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
+"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`.
+
+Set `lazy=true` to express symbolic sums, products, and tensor products using the lazy operator
+types from `QuantumOpticsBase` (`LazySum`, `LazyProduct`, `LazyTensor`) where the basis structure
+supports it, instead of eagerly materializing dense operators."""
+Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation
     cutoff::Int = 2
+    lazy::Bool = false
 end
+# Preserve the single positional-argument constructor `QuantumOpticsRepr(cutoff)`, which the
+# `@kwdef`-generated all-positional constructor would otherwise shadow once a second field exists.
+QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(; cutoff)
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end
 """Representation using tableaux governed by `QuantumClifford.jl`"""


### PR DESCRIPTION
## Summary
Part of [qojulia/QuantumOptics.jl#521](https://github.com/qojulia/QuantumOptics.jl/issues/521) (unitaryHACK26).

Adds a `lazy::Bool=false` field to `QuantumOpticsRepr` so that downstream packages (QuantumSymbolics.jl) can opt into structure-preserving lazy operator output. The existing `QuantumOpticsRepr()` and `QuantumOpticsRepr(cutoff)` constructors are preserved via an explicit single-argument constructor.

## Changes
- `lazy` field on `QuantumOpticsRepr` (default `false`)
- Preserved `QuantumOpticsRepr()` and `QuantumOpticsRepr(cutoff)` constructors
- Version 0.4.2 → 0.4.3, CHANGELOG

## Test plan
- [ ] CI passes (`Pkg.test()` on Julia 1.x and 1.6)