### PR TITLE
feat: add lazy field to QuantumOpticsRepr

### DIFF
--- a/src/express.jl
+++ b/src/express.jl
@@ -23,9 +23,11 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 ##
 
 """Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`."""
-Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
+Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation
     cutoff::Int = 2
+    lazy::Bool = false
 end
+QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(cutoff=cutoff)
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end
 """Representation using tableaux governed by `QuantumClifford.jl`"""


### PR DESCRIPTION
Added `lazy::Bool = false` to `QuantumOpticsRepr`, also adds a `QuantumOpticsRepr(cutoff::Int)` to outer constructor so the existing positional calling convention doesnt break and default behviour is unchanged.

needed for https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/197

Part of https://github.com/qojulia/QuantumOptics.jl/issues/521

