### PR TITLE
Add lazy option to QuantumOpticsRepr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v0.4.3 - 2026-06-08
+
+- Add a `lazy` option to `QuantumOpticsRepr`.
+
 ## v0.4.2 - 2025-11-29
 
 - Define `commutator` and `anticommutator`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumInterface"
 uuid = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
 authors = ["QuantumInterface.jl contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/express.jl
+++ b/src/express.jl
@@ -22,10 +22,16 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 # Commonly used representations -- interfaces for each one defined in separate packages
 ##
 
-"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`."""
+"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`.
+
+Set `lazy=true` to request structure-preserving lazy operators where supported by
+the target package.
+"""
 Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
     cutoff::Int = 2
+    lazy::Bool = false
 end
+QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(cutoff=cutoff)
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end
 """Representation using tableaux governed by `QuantumClifford.jl`"""

--- a/src/express.jl
+++ b/src/express.jl
@@ -27,10 +27,11 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 Set `lazy=true` to request structure-preserving lazy operators where supported by
 the target package.
 """
-Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
-    cutoff::Int = 2
-    lazy::Bool = false
+struct QuantumOpticsRepr <: AbstractRepresentation
+    cutoff::Int
+    lazy::Bool
 end
+QuantumOpticsRepr(; cutoff::Int=2, lazy::Bool=false) = QuantumOpticsRepr(cutoff, lazy)
 QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(cutoff=cutoff)
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end

--- a/test/test_bases.jl
+++ b/test/test_bases.jl
@@ -1,6 +1,6 @@
 using Test
 using QuantumInterface: tensor, ⊗, ptrace, reduced, permutesystems, multiplicable
-using QuantumInterface: GenericBasis, CompositeBasis, NLevelBasis, FockBasis
+using QuantumInterface: GenericBasis, CompositeBasis, NLevelBasis, FockBasis, QuantumOpticsRepr
 
 @testset "basis" begin
 
@@ -55,12 +55,12 @@ comp2 = tensor(b2, b1, b3)
 end # testset
 
 @testset "representations" begin
-    @test QuantumInterface.QuantumOpticsRepr().cutoff == 2
-    @test QuantumInterface.QuantumOpticsRepr().lazy == false
-    @test QuantumInterface.QuantumOpticsRepr(5).cutoff == 5
-    @test QuantumInterface.QuantumOpticsRepr(5).lazy == false
-    @test QuantumInterface.QuantumOpticsRepr(lazy=true).cutoff == 2
-    @test QuantumInterface.QuantumOpticsRepr(lazy=true).lazy == true
-    @test QuantumInterface.QuantumOpticsRepr(cutoff=4, lazy=true).cutoff == 4
-    @test QuantumInterface.QuantumOpticsRepr(cutoff=4, lazy=true).lazy == true
+    @test QuantumOpticsRepr().cutoff == 2
+    @test QuantumOpticsRepr().lazy == false
+    @test QuantumOpticsRepr(5).cutoff == 5
+    @test QuantumOpticsRepr(5).lazy == false
+    @test QuantumOpticsRepr(lazy=true).cutoff == 2
+    @test QuantumOpticsRepr(lazy=true).lazy == true
+    @test QuantumOpticsRepr(cutoff=4, lazy=true).cutoff == 4
+    @test QuantumOpticsRepr(cutoff=4, lazy=true).lazy == true
 end

--- a/test/test_bases.jl
+++ b/test/test_bases.jl
@@ -53,3 +53,14 @@ comp2 = tensor(b2, b1, b3)
 @test !multiplicable(comp1, b1 ⊗ b2 ⊗ NLevelBasis(prod(b3.shape)))
 
 end # testset
+
+@testset "representations" begin
+    @test QuantumInterface.QuantumOpticsRepr().cutoff == 2
+    @test QuantumInterface.QuantumOpticsRepr().lazy == false
+    @test QuantumInterface.QuantumOpticsRepr(5).cutoff == 5
+    @test QuantumInterface.QuantumOpticsRepr(5).lazy == false
+    @test QuantumInterface.QuantumOpticsRepr(lazy=true).cutoff == 2
+    @test QuantumInterface.QuantumOpticsRepr(lazy=true).lazy == true
+    @test QuantumInterface.QuantumOpticsRepr(cutoff=4, lazy=true).cutoff == 4
+    @test QuantumInterface.QuantumOpticsRepr(cutoff=4, lazy=true).lazy == true
+end


### PR DESCRIPTION
## Summary
- add a `lazy::Bool=false` field to `QuantumOpticsRepr`
- preserve the existing `QuantumOpticsRepr(cutoff)` positional constructor
- document that lazy output is opt-in for downstream packages

This supports qojulia/QuantumOptics.jl#521, where QuantumSymbolics needs to request structure-preserving QuantumOptics lazy operators.

## Testing
- Not run locally: Julia is not installed in this environment.

## AI assistance disclosure
AI assistance was used to inspect the codebase and draft this patch.