### PR TITLE
Add `lazy::Bool` field to `QuantumOpticsRepr`

### DIFF
--- a/src/express.jl
+++ b/src/express.jl
@@ -25,6 +25,7 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 """Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`."""
 Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
     cutoff::Int = 2
+    lazy::Bool = false
 end
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end


### PR DESCRIPTION
This adds a `lazy::Bool = false` keyword argument to `QuantumOpticsRepr`, enabling opt-in lazy operator output when expressing symbolic quantum objects via `QuantumSymbolics.jl`.

### What changed

A single field addition to the `@kwdef` struct in `src/express.jl`:

```julia
Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
    cutoff::Int = 2
    lazy::Bool = false
end
```

### Backward compatibility

All existing constructor forms continue to work unchanged:

- `QuantumOpticsRepr()` → `cutoff=2, lazy=false`
- `QuantumOpticsRepr(4)` → `cutoff=4, lazy=false`
- `QuantumOpticsRepr(cutoff=4)` → `cutoff=4, lazy=false`

New usage:

- `QuantumOpticsRepr(lazy=true)` → `cutoff=2, lazy=true`
- `QuantumOpticsRepr(cutoff=4, lazy=true)` → `cutoff=4, lazy=true`

### Context

This is the first half of the work for [qojulia/QuantumOptics.jl#521](https://github.com/qojulia/QuantumOptics.jl/issues/521). The companion PR implementing the lazy `express_nolookup` dispatch methods will go to `QuantumSavory/QuantumSymbolics.jl`.