### PR TITLE
Add lazy field to QuantumOpticsRepr (qojulia/QuantumOptics.jl#521)

### DIFF
--- a/src/express.jl
+++ b/src/express.jl
@@ -22,10 +22,17 @@ express(s, repr::AbstractRepresentation) = express(s, repr, UseAsState())
 # Commonly used representations -- interfaces for each one defined in separate packages
 ##
 
-"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`."""
-Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation 
+"""Representation using kets, bras, density matrices, and superoperators governed by `QuantumOptics.jl`.
+
+When `lazy=true`, composite symbolic expressions (sums, products, tensor products)
+are expressed into structure-preserving lazy operators (`LazySum`, `LazyProduct`,
+`LazyTensor`) instead of eagerly-materialised dense/sparse operators."""
+Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation
     cutoff::Int = 2
+    lazy::Bool = false
 end
+# preserve the historical positional one-argument constructor QuantumOpticsRepr(cutoff)
+QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(cutoff, false)
 """Similar to `QuantumOpticsRepr`, but using trajectories instead of superoperators."""
 struct QuantumMCRepr <: AbstractRepresentation end
 """Representation using tableaux governed by `QuantumClifford.jl`"""


### PR DESCRIPTION
Part 1 of 2 for qojulia/QuantumOptics.jl#521 (lazy operator support).
## The ask
Add a `lazy::Bool=false` keyword to `QuantumOpticsRepr` so that
`express(x, QuantumOpticsRepr(lazy=true))` produces structure-preserving lazy
operators: symbolic **sum → `LazySum`**, **product → `LazyProduct`**,
**tensor → `LazyTensor`**, with `dense(lazy) ≈ eager` and backward compatibility
for `QuantumOpticsRepr()` / `QuantumOpticsRepr(cutoff)`.

## The key insights
QuantumSymbolics expresses a composite symbolic expression via
`operation(s)(express.(arguments(s))...)` — it applies the symbolic operation
(`+`, `*`, `⊗`) to the eagerly-expressed arguments. **Making it lazy = swap the
operation for its lazy constructor.** `operation()` is `+` for `SAdd`, `*` for
`SMulOperator`/`SScaled`, `⊗` for `STensor` (verified in source), so a single
dispatch on the operation suffices.

## Changes (2 repos → 2 coordinated PRs)

### 1. `QuantumInterface.jl` — `src/express.jl`
```julia
Base.@kwdef struct QuantumOpticsRepr <: AbstractRepresentation
    cutoff::Int = 2
    lazy::Bool = false          # NEW
end
QuantumOpticsRepr(cutoff::Int) = QuantumOpticsRepr(cutoff, false)  # keep 1-arg ctor
```
The explicit 1-arg constructor is required because `@kwdef` with two fields makes
the positional constructor need both args — without it, `QuantumOpticsRepr(2)`
(a documented usage) would break.

### 2. `QuantumSymbolics.jl` — `ext/QuantumOpticsExt/QuantumOpticsExt.jl`  https://github.com/QuantumSavory/QuantumSymbolics.jl/pull/201
A `express_nolookup(s, repr::QuantumOpticsRepr)` method that, when `repr.lazy`,
maps the operation to its lazy constructor (and otherwise reproduces the eager
behaviour exactly). Guards ensure ket/bra cases (which also carry `operation===*`)
fall through to eager, and that `LazyTensor` (which needs densifiable factors)
collapses any lazy *factor* while keeping the tensor product itself lazy.
Plus `test/general/express_lazy_tests.jl` (auto-discovered) and a paragraph in
`docs/src/express.md`.

## Validation (local, Julia 1.12.6, dev-linked QuantumInterface)
| test | result |
|---|---|
| new `express_lazy_tests.jl` (constructor, backcompat, sum/product/tensor, dense≈eager, scalar, nesting, eager-unchanged) | **12/12 pass** |
| existing `express_opt_tests.jl` (eager sums/products/tensors/mixed) | **15/15 pass** — no regression |
| `basis_consistency_tests.jl` | pass |

## Files changed (PR contents)
```
QuantumInterface.jl:
  src/express.jl                                   (+ lazy field, + 1-arg ctor)
QuantumSymbolics.jl:
  ext/QuantumOpticsExt/QuantumOpticsExt.jl         (+ lazy express method)
  test/general/express_lazy_tests.jl               (new)
  docs/src/express.md                              (+ lazy paragraph)
```
**AI Acknowledgment:** i want to thank claude opus 4.6 for making me understand code base of both repos and helpin me running testing and validations