### PR TITLE
Simplify downgrade CI on Julia 1.12

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -8,23 +8,31 @@ on:
     branches: [master, main]
     paths-ignore:
       - 'docs/**'
-env:
-  PYTHON: ~
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ['1.10']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML,InteractiveUtils,Random,LinearAlgebra
+          version: '1.12'
       - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - uses: julia-actions/julia-downgrade-compat@v2.7.0
+        with:
+          projects: '.,test'
+          mode: 'forcedeps'
+          julia_version: '1.12'
+          skip: LinearAlgebra,SparseArrays,Test
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,25 +23,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.9'
+          version: '1.12'
+      - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
           skip: LinearAlgebra,SparseArrays,Test
-          mode: 'deps'
-          julia_version: 'min'
-      - name: Remove unsupported Julia 1.6 manifest metadata
-        run: sed -i '/^project_hash = /d' Manifest.toml test/Manifest.toml
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: 'min'
-      - uses: julia-actions/cache@v3
-        with:
-          delete-old-caches: false
+          mode: 'forcedeps'
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Instantiate the locked test environment
-        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
-      - name: Run tests without re-resolving
-        env:
-          JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"
-        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
+          skip: LinearAlgebra,SparseArrays,Test
           mode: 'forcedeps'
           julia_version: '1.12'
-          skip: LinearAlgebra,SparseArrays,Test
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,18 +23,25 @@ jobs:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
         with:
-          version: '1.12'
-      - uses: julia-actions/cache@v3
-        with:
-          delete-old-caches: false
+          version: '1.9'
       - uses: julia-actions/julia-downgrade-compat@v2.7.0
         with:
           projects: '.,test'
           skip: LinearAlgebra,SparseArrays,Test
-          mode: 'forcedeps'
-          julia_version: '1.12'
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+          mode: 'deps'
+          julia_version: 'min'
+      - name: Remove unsupported Julia 1.6 manifest metadata
+        run: sed -i '/^project_hash = /d' Manifest.toml test/Manifest.toml
+      - uses: julia-actions/setup-julia@v3
         with:
-          allow_reresolve: false
-          force_latest_compatible_version: false
+          version: 'min'
+      - uses: julia-actions/cache@v3
+        with:
+          delete-old-caches: false
+      - uses: julia-actions/julia-buildpkg@v1
+      - name: Instantiate the locked test environment
+        run: julia --color=yes --project=test -e 'import Pkg; Pkg.instantiate()'
+      - name: Run tests without re-resolving
+        env:
+          JULIA_LOAD_PATH: "${{ github.workspace }}/test:${{ github.workspace }}:@stdlib"
+        run: julia --color=yes --check-bounds=yes --project=test test/runtests.jl


### PR DESCRIPTION
## Summary
- run lower-bound resolution and testing on Julia 1.12
- resolve root and split test environments together, then build and test the locked graph
- disable both `Pkg.test` re-resolution paths
- remove pre-1.12 setup, manifest-repair, workspace-rewrite, and direct-test workarounds
- retain strict `forcedeps` verification and only the required stdlib exclusions

No compat bounds are added to `test/Project.toml`.

## Validation
- `actionlint`
- all Project TOML files parsed with Julia 1.12
- aggregate workflow-contract and stdlib-skip checks
- targeted locked-manifest runs on representative and exceptional repositories
- two independent cross-repository reviews

Existing package lower-bound failures are intentionally left visible for separate follow-up.